### PR TITLE
Truncate list of author names

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,3 +6,4 @@
 //= require blacklight/blacklight
 //= require jquery_ujs
 //= require turbolinks
+//= require readmore

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,3 +7,4 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require readmore
+//= require readmore-call

--- a/app/assets/javascripts/readmore-call.js
+++ b/app/assets/javascripts/readmore-call.js
@@ -1,0 +1,7 @@
+$(document).ready(function(){
+  $('.blacklight-author_ssim').readmore({
+  collapsedHeight: 25,
+  lessLink: '<a href="#">View fewer authors</a>',
+  moreLink: '<a href="#">View all authors</a>'
+  });
+});

--- a/app/assets/javascripts/readmore.js
+++ b/app/assets/javascripts/readmore.js
@@ -1,0 +1,342 @@
+/*!
+ * @preserve
+ *
+ * Readmore.js jQuery plugin
+ * Author: @jed_foster
+ * Project home: http://jedfoster.github.io/Readmore.js
+ * Licensed under the MIT license
+ *
+ * Debounce function from http://davidwalsh.name/javascript-debounce-function
+ */
+
+/* global jQuery */
+
+(function(factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD
+    define(['jquery'], factory);
+  } else if (typeof exports === 'object') {
+    // CommonJS
+    module.exports = factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function($) {
+  'use strict';
+
+  var readmore = 'readmore',
+      defaults = {
+        speed: 100,
+        collapsedHeight: 200,
+        heightMargin: 16,
+        moreLink: '<a href="#">Read More</a>',
+        lessLink: '<a href="#">Close</a>',
+        embedCSS: true,
+        blockCSS: 'display: block; width: 100%;',
+        startOpen: false,
+
+        // callbacks
+        blockProcessed: function() {},
+        beforeToggle: function() {},
+        afterToggle: function() {}
+      },
+      cssEmbedded = {},
+      uniqueIdCounter = 0;
+
+  function debounce(func, wait, immediate) {
+    var timeout;
+
+    return function() {
+      var context = this, args = arguments;
+      var later = function() {
+        timeout = null;
+        if (! immediate) {
+          func.apply(context, args);
+        }
+      };
+      var callNow = immediate && !timeout;
+
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+
+      if (callNow) {
+        func.apply(context, args);
+      }
+    };
+  }
+
+  function uniqueId(prefix) {
+    var id = ++uniqueIdCounter;
+
+    return String(prefix == null ? 'rmjs-' : prefix) + id;
+  }
+
+  function setBoxHeights(element) {
+    var el = element.clone().css({
+          height: 'auto',
+          width: element.width(),
+          maxHeight: 'none',
+          overflow: 'hidden'
+        }).insertAfter(element),
+        expandedHeight = el.outerHeight(),
+        cssMaxHeight = parseInt(el.css({maxHeight: ''}).css('max-height').replace(/[^-\d\.]/g, ''), 10),
+        defaultHeight = element.data('defaultHeight');
+
+    el.remove();
+
+    var collapsedHeight = cssMaxHeight || element.data('collapsedHeight') || defaultHeight;
+
+    // Store our measurements.
+    element.data({
+      expandedHeight: expandedHeight,
+      maxHeight: cssMaxHeight,
+      collapsedHeight: collapsedHeight
+    })
+    // and disable any `max-height` property set in CSS
+    .css({
+      maxHeight: 'none'
+    });
+  }
+
+  var resizeBoxes = debounce(function() {
+    $('[data-readmore]').each(function() {
+      var current = $(this),
+          isExpanded = (current.attr('aria-expanded') === 'true');
+
+      setBoxHeights(current);
+
+      current.css({
+        height: current.data( (isExpanded ? 'expandedHeight' : 'collapsedHeight') )
+      });
+    });
+  }, 100);
+
+  function embedCSS(options) {
+    if (! cssEmbedded[options.selector]) {
+      var styles = ' ';
+
+      if (options.embedCSS && options.blockCSS !== '') {
+        styles += options.selector + ' + [data-readmore-toggle], ' +
+          options.selector + '[data-readmore]{' +
+            options.blockCSS +
+          '}';
+      }
+
+      // Include the transition CSS even if embedCSS is false
+      styles += options.selector + '[data-readmore]{' +
+        'transition: height ' + options.speed + 'ms;' +
+        'overflow: hidden;' +
+      '}';
+
+      (function(d, u) {
+        var css = d.createElement('style');
+        css.type = 'text/css';
+
+        if (css.styleSheet) {
+          css.styleSheet.cssText = u;
+        }
+        else {
+          css.appendChild(d.createTextNode(u));
+        }
+
+        d.getElementsByTagName('head')[0].appendChild(css);
+      }(document, styles));
+
+      cssEmbedded[options.selector] = true;
+    }
+  }
+
+  function Readmore(element, options) {
+    this.element = element;
+
+    this.options = $.extend({}, defaults, options);
+
+    embedCSS(this.options);
+
+    this._defaults = defaults;
+    this._name = readmore;
+
+    this.init();
+
+    // IE8 chokes on `window.addEventListener`, so need to test for support.
+    if (window.addEventListener) {
+      // Need to resize boxes when the page has fully loaded.
+      window.addEventListener('load', resizeBoxes);
+      window.addEventListener('resize', resizeBoxes);
+    }
+    else {
+      window.attachEvent('load', resizeBoxes);
+      window.attachEvent('resize', resizeBoxes);
+    }
+  }
+
+
+  Readmore.prototype = {
+    init: function() {
+      var current = $(this.element);
+
+      current.data({
+        defaultHeight: this.options.collapsedHeight,
+        heightMargin: this.options.heightMargin
+      });
+
+      setBoxHeights(current);
+
+      var collapsedHeight = current.data('collapsedHeight'),
+          heightMargin = current.data('heightMargin');
+
+      if (current.outerHeight(true) <= collapsedHeight + heightMargin) {
+        // The block is shorter than the limit, so there's no need to truncate it.
+        if (this.options.blockProcessed && typeof this.options.blockProcessed === 'function') {
+          this.options.blockProcessed(current, false);
+        }
+        return true;
+      }
+      else {
+        var id = current.attr('id') || uniqueId(),
+            useLink = this.options.startOpen ? this.options.lessLink : this.options.moreLink;
+
+        current.attr({
+          'data-readmore': '',
+          'aria-expanded': this.options.startOpen,
+          'id': id
+        });
+
+        current.after($(useLink)
+          .on('click', (function(_this) {
+            return function(event) {
+              _this.toggle(this, current[0], event);
+            };
+          })(this))
+          .attr({
+            'data-readmore-toggle': id,
+            'aria-controls': id
+          }));
+
+        if (! this.options.startOpen) {
+          current.css({
+            height: collapsedHeight
+          });
+        }
+
+        if (this.options.blockProcessed && typeof this.options.blockProcessed === 'function') {
+          this.options.blockProcessed(current, true);
+        }
+      }
+    },
+
+    toggle: function(trigger, element, event) {
+      if (event) {
+        event.preventDefault();
+      }
+
+      if (! trigger) {
+        trigger = $('[aria-controls="' + this.element.id + '"]')[0];
+      }
+
+      if (! element) {
+        element = this.element;
+      }
+
+      var $element = $(element),
+          newHeight = '',
+          newLink = '',
+          expanded = false,
+          collapsedHeight = $element.data('collapsedHeight');
+
+      if ($element.height() <= collapsedHeight) {
+        newHeight = $element.data('expandedHeight') + 'px';
+        newLink = 'lessLink';
+        expanded = true;
+      }
+      else {
+        newHeight = collapsedHeight;
+        newLink = 'moreLink';
+      }
+
+      // Fire beforeToggle callback
+      // Since we determined the new "expanded" state above we're now out of sync
+      // with our true current state, so we need to flip the value of `expanded`
+      if (this.options.beforeToggle && typeof this.options.beforeToggle === 'function') {
+        this.options.beforeToggle(trigger, $element, ! expanded);
+      }
+
+      $element.css({'height': newHeight});
+
+      // Fire afterToggle callback
+      $element.on('transitionend', (function(_this) {
+        return function() {
+          if (_this.options.afterToggle && typeof _this.options.afterToggle === 'function') {
+            _this.options.afterToggle(trigger, $element, expanded);
+          }
+
+          $(this).attr({
+            'aria-expanded': expanded
+          }).off('transitionend');
+        }
+      })(this));
+
+      $(trigger).replaceWith($(this.options[newLink])
+        .on('click', (function(_this) {
+            return function(event) {
+              _this.toggle(this, element, event);
+            };
+          })(this))
+        .attr({
+          'data-readmore-toggle': $element.attr('id'),
+          'aria-controls': $element.attr('id')
+        }));
+    },
+
+    destroy: function() {
+      $(this.element).each(function() {
+        var current = $(this);
+
+        current.attr({
+          'data-readmore': null,
+          'aria-expanded': null
+        })
+          .css({
+            maxHeight: '',
+            height: ''
+          })
+          .next('[data-readmore-toggle]')
+          .remove();
+
+        current.removeData();
+      });
+    }
+  };
+
+
+  $.fn.readmore = function(options) {
+    var args = arguments,
+        selector = this.selector;
+
+    options = options || {};
+
+    if (typeof options === 'object') {
+      return this.each(function() {
+        if ($.data(this, 'plugin_' + readmore)) {
+          var instance = $.data(this, 'plugin_' + readmore);
+          instance.destroy.apply(instance);
+        }
+
+        options.selector = selector;
+
+        $.data(this, 'plugin_' + readmore, new Readmore(this, options));
+      });
+    }
+    else if (typeof options === 'string' && options[0] !== '_' && options !== 'init') {
+      return this.each(function () {
+        var instance = $.data(this, 'plugin_' + readmore);
+        if (instance instanceof Readmore && typeof instance[options] === 'function') {
+          instance[options].apply(instance, Array.prototype.slice.call(args, 1));
+        }
+      });
+    }
+  };
+
+}));
+

--- a/app/assets/javascripts/readmore.js
+++ b/app/assets/javascripts/readmore.js
@@ -9,6 +9,8 @@
  * Debounce function from http://davidwalsh.name/javascript-debounce-function
  */
 
+ /* v2.2.0 */
+
 /* global jQuery */
 
 (function(factory) {
@@ -339,4 +341,3 @@
   };
 
 }));
-

--- a/app/assets/stylesheets/partials/item-page.scss
+++ b/app/assets/stylesheets/partials/item-page.scss
@@ -71,6 +71,10 @@
     margin: 0;
   }
 
+  & .blacklight-author_ssim span {
+    white-space: nowrap;
+  }
+
   & .blacklight-author_ssim + [data-readmore-toggle] {
     background: $gray-lighter-custom;
     font-size: 12px;

--- a/app/assets/stylesheets/partials/item-page.scss
+++ b/app/assets/stylesheets/partials/item-page.scss
@@ -65,14 +65,14 @@
 
   & .blacklight-author_ssim {
     color: $gray-light;
-    margin: 12px 0 30px 0;
+    display: inline-block;
   }
 
-  & p {
+  & p.blacklight-abstract_ssi {
     font-size: 17px;
     font-weight: 300;
     line-height: 1.6;
-    margin: 0 0 30px 0;
+    margin: 30px 0;
   }
 
   & .subjects h4 {

--- a/app/assets/stylesheets/partials/item-page.scss
+++ b/app/assets/stylesheets/partials/item-page.scss
@@ -66,6 +66,15 @@
   & .blacklight-author_ssim {
     color: $gray-light;
     display: inline-block;
+    font-size: 16px;
+    line-height: 1.7;
+  }
+
+  & .blacklight-author_ssim + [data-readmore-toggle] {
+    background: #eee;
+    font-size: 12px;
+    display: inline;
+    padding: 2px 5px;
   }
 
   & p.blacklight-abstract_ssi {

--- a/app/assets/stylesheets/partials/item-page.scss
+++ b/app/assets/stylesheets/partials/item-page.scss
@@ -68,10 +68,11 @@
     display: inline-block;
     font-size: 16px;
     line-height: 1.7;
+    margin: 0;
   }
 
   & .blacklight-author_ssim + [data-readmore-toggle] {
-    background: #eee;
+    background: $gray-lighter-custom;
     font-size: 12px;
     display: inline;
     padding: 2px 5px;

--- a/app/assets/stylesheets/partials/search-results.scss
+++ b/app/assets/stylesheets/partials/search-results.scss
@@ -58,6 +58,9 @@
 
   & dd.blacklight-author_ssim {
     margin: 0 0 13px 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   & dd.blacklight-pub_date_isi,

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -9,11 +9,13 @@
 <% doc_presenter = show_presenter(document) %>
 
 <%# Render tags under title %>
+<p>
 <% document_show_fields(document).select { |name, f| f[:display] == :tag }.each do |field_name, field| -%>
   <% if should_render_show_field? document, field %>
     <span class="label-tags"><%= doc_presenter.field_value field_name %></span>
   <% end -%>
 <% end -%>
+</p>
 
 <%# Render author and abstract %>
 <% document_show_fields(document).select { |name, f| f[:display] == :main_content }.each do |field_name, field| -%>
@@ -21,6 +23,15 @@
     <p class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></p>
   <% end -%>
 <% end -%>
+
+<%# Truncate author list %>
+<script>
+$('.blacklight-author_ssim').readmore({
+  collapsedHeight: 20,
+  lessLink: '<a href="#">View fewer authors</a>',
+  moreLink: '<a href="#">View all authors</a>'
+});
+</script>
 
 <%# Render table fields %>
 <% document_show_fields(document).select { |name, f| f[:display] == :table }.each do |field_name, field| -%>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -24,15 +24,6 @@
   <% end -%>
 <% end -%>
 
-<%# Truncate author list %>
-<script>
-$('.blacklight-author_ssim').readmore({
-  collapsedHeight: 25,
-  lessLink: '<a href="#">View fewer authors</a>',
-  moreLink: '<a href="#">View all authors</a>'
-});
-</script>
-
 <%# Render table fields %>
 <% document_show_fields(document).select { |name, f| f[:display] == :table }.each do |field_name, field| -%>
   <% if should_render_show_field? document, field %>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -27,7 +27,7 @@
 <%# Truncate author list %>
 <script>
 $('.blacklight-author_ssim').readmore({
-  collapsedHeight: 20,
+  collapsedHeight: 25,
   lessLink: '<a href="#">View fewer authors</a>',
   moreLink: '<a href="#">View all authors</a>'
 });


### PR DESCRIPTION
- adds readmore.js jquery plugin to truncate list of author names on item pages, with option to view all names. 
https://github.com/jedfoster/Readmore.js

- for search results page, adds css to truncate author names with ellipses