### PR TITLE
Fixes issue where fixed sidebar was being applied to item pages

### DIFF
--- a/app/assets/javascripts/sticky-sidebar.js
+++ b/app/assets/javascripts/sticky-sidebar.js
@@ -1,7 +1,7 @@
 $(document).ready(function(){
   var navHeight = $('.navbar').outerHeight(true) + 10;
 
-  $('#sidebar').affix({
+  $('#sidebar-fixed').affix({
     offset: {
       top: 300,
       bottom: navHeight

--- a/app/assets/javascripts/sticky-sidebar.js
+++ b/app/assets/javascripts/sticky-sidebar.js
@@ -1,7 +1,7 @@
 $(document).ready(function(){
   var navHeight = $('.navbar').outerHeight(true) + 10;
 
-  $('#sidebar-fixed').affix({
+  $('#static-text #sidebar').affix({
     offset: {
       top: 300,
       bottom: navHeight

--- a/app/assets/stylesheets/partials/static-page.scss
+++ b/app/assets/stylesheets/partials/static-page.scss
@@ -126,33 +126,29 @@
       position: static;
     }
 
-    & #sidebar.affix-top {
-      position: static;
+    & .affix,
+    & .affix-bottom,
+    & .affix-top {
       width: 234px;
     }
 
-    & #sidebar.affix,
-    & #sidebar.affix-bottom {
-      width: 234px;
-    }
-
-    & #sidebar.affix {
+    & .affix {
       position: fixed;
       top: 0;
     }
 
-    & #sidebar.affix-bottom {
+    & .affix-bottom {
       position: absolute;
     }
 
 	  & ul.anchor-links li {
-				display: block;
-	      line-height: 2;
-	    }
+			display: block;
+      line-height: 2;
+    }
 
 	  & ul.anchor-links li::after {
-				content: none;
-			}
+			content: none;
+		}
 
 		& #main-content {
 			border-left: 1px solid $gray-lighter;

--- a/app/assets/stylesheets/partials/static-page.scss
+++ b/app/assets/stylesheets/partials/static-page.scss
@@ -126,28 +126,24 @@
   	position: static;
   }
 
-  #sidebar.affix-top {
+  #sidebar-fixed.affix-top {
      position: static;
      width: 234px;
    }
 
-   #sidebar.affix,
-   #sidebar.affix-bottom {
+   #sidebar-fixed.affix,
+   #sidebar-fixed.affix-bottom {
      width: 234px;
    }
 
-   #sidebar.affix {
+   #sidebar-fixed.affix {
      position: fixed;
      top: 0;
    }
 
-   #sidebar.affix-bottom {
+   #sidebar-fixed.affix-bottom {
      position: absolute;
    }
-
-  #fixed-sidebar {
-    padding: 0 0 0 15px;
-  }
 
   #static-text {
 

--- a/app/assets/stylesheets/partials/static-page.scss
+++ b/app/assets/stylesheets/partials/static-page.scss
@@ -2,6 +2,11 @@
 
 #static-text {
 
+  & .affix-top,
+  & .affix {
+  	position: relative;
+  }
+
   & a {
     text-decoration: underline;
   }
@@ -110,42 +115,35 @@
   }
 }
 
-/* fixed sidebar */
-
-.affix-top,
-.affix {
-	position: relative;
-}
-
 /* desktop view */
 
 @media screen and (min-width: $screen-md ) {
 
-  .affix-top,
-  .affix {
-  	position: static;
-  }
-
-  #sidebar-fixed.affix-top {
-     position: static;
-     width: 234px;
-   }
-
-   #sidebar-fixed.affix,
-   #sidebar-fixed.affix-bottom {
-     width: 234px;
-   }
-
-   #sidebar-fixed.affix {
-     position: fixed;
-     top: 0;
-   }
-
-   #sidebar-fixed.affix-bottom {
-     position: absolute;
-   }
-
   #static-text {
+
+    & .affix-top,
+    & .affix {
+      position: static;
+    }
+
+    & #sidebar.affix-top {
+      position: static;
+      width: 234px;
+    }
+
+    & #sidebar.affix,
+    & #sidebar.affix-bottom {
+      width: 234px;
+    }
+
+    & #sidebar.affix {
+      position: fixed;
+      top: 0;
+    }
+
+    & #sidebar.affix-bottom {
+      position: absolute;
+    }
 
 	  & ul.anchor-links li {
 				display: block;

--- a/app/views/info/faq.html.erb
+++ b/app/views/info/faq.html.erb
@@ -10,7 +10,7 @@
     <div class="row">
 
       <div class="col-md-2">
-        <ul class="anchor-links" id="sidebar-fixed">
+        <ul class="anchor-links" id="sidebar">
          <li><%= link_to 'Deposit', '#deposit' %></li>
          <li><%= link_to 'Manage', '#manage' %></li>
          <li><%= link_to 'Copyright', '#copyright' %></li>

--- a/app/views/info/faq.html.erb
+++ b/app/views/info/faq.html.erb
@@ -9,8 +9,8 @@
   <div class="container">
     <div class="row">
 
-      <div class="col-md-2" id="fixed-sidebar">
-        <ul class="anchor-links" id="sidebar">
+      <div class="col-md-2">
+        <ul class="anchor-links" id="sidebar-fixed">
          <li><%= link_to 'Deposit', '#deposit' %></li>
          <li><%= link_to 'Manage', '#manage' %></li>
          <li><%= link_to 'Copyright', '#copyright' %></li>

--- a/app/views/info/policies.html.erb
+++ b/app/views/info/policies.html.erb
@@ -10,7 +10,7 @@
     <div class="row">
 
       <div class="col-md-2">
-        <ul class="anchor-links" id="sidebar-fixed">
+        <ul class="anchor-links" id="sidebar">
          <li><%= link_to 'Deposit', '#deposit' %></li>
          <li><%= link_to 'Terms of Use', '#terms-of-use' %></li>
          <li><%= link_to 'Copyright', '#copyright' %></li>

--- a/app/views/info/policies.html.erb
+++ b/app/views/info/policies.html.erb
@@ -9,8 +9,8 @@
   <div class="container">
     <div class="row">
 
-      <div class="col-md-2" id="fixed-sidebar">
-        <ul class="anchor-links" id="sidebar">
+      <div class="col-md-2">
+        <ul class="anchor-links" id="sidebar-fixed">
          <li><%= link_to 'Deposit', '#deposit' %></li>
          <li><%= link_to 'Terms of Use', '#terms-of-use' %></li>
          <li><%= link_to 'Copyright', '#copyright' %></li>


### PR DESCRIPTION
I didn't realize item pages were using same sidebar id (#sidebar) as static pages, so the item page sidebar was getting fixed in an undesirable way. 

Added a unique sidebar id for static pages. 