### PR TITLE
Span around subjects

### DIFF
--- a/app/assets/stylesheets/partials/facets-sidenav.scss
+++ b/app/assets/stylesheets/partials/facets-sidenav.scss
@@ -59,6 +59,10 @@
   & .remove {
     text-indent: 7px;
   }
+
+  & p.subsection {
+    font-size: 12px;
+  }
 }
 
 @media screen and (min-width: $screen-md ) {

--- a/app/assets/stylesheets/partials/search-results.scss
+++ b/app/assets/stylesheets/partials/search-results.scss
@@ -2,8 +2,6 @@
 
 .well {
   background: $gray-lighter-custom;
-  // box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
-  // border: 3px solid $gray-lighter;
   border: none;
   box-shadow: none;
 }
@@ -14,6 +12,7 @@
 }
 
 #sortAndPerPage {
+  border-bottom: 0;
   font-size: 14px;
   margin: 0;
   padding-bottom: 10px;
@@ -31,8 +30,10 @@
   margin-bottom: 30px;
 
   & .document {
-    margin: 0;
-    padding: 15px 0;
+    border: 1px dotted #ccc;
+    border-radius: 3px;
+    margin: 0 0 5px 0;
+    padding: 17px 15px 12px 15px;
   }
 
   & .document-counter {
@@ -81,7 +82,6 @@
     margin: 0 6px 6px 0;
     padding: 3px 7px;
     white-space: nowrap;
-
   }
 }
 

--- a/app/assets/stylesheets/partials/search-results.scss
+++ b/app/assets/stylesheets/partials/search-results.scss
@@ -32,7 +32,7 @@
 
   & .document {
     margin: 0;
-    padding: 25px 0;
+    padding: 15px 0;
   }
 
   & .document-counter {
@@ -43,11 +43,10 @@
     font-size: 21px;
     letter-spacing: .2px;
     line-height: 1.3;
-    margin: 0 0 10px 0;
+    margin: 0 0 8px 0;
   }
 
   & .document-metadata dd {
-    color: $gray-light;
     font-size: 14px;
     margin: 0;
   }
@@ -57,31 +56,32 @@
   }
 
   & dd.blacklight-author_ssim {
-    margin: 0 0 10px 0;
+    margin: 0 0 8px 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  & dd.blacklight-subject_ssim {
-    margin: 0 0 10px 0;
-  }
-
-  & dd.blacklight-subject_ssim span {
-    background: $gray-lighter-custom;
-    border-radius: 3px;
-    margin: 0 5px 0 0;
-    padding: 3px 7px;
-  }
-
   & dd.blacklight-pub_date_isi,
   & dd.blacklight-genre_ssim {
     @include label-tags;
+    margin-bottom: 13px;
   }
 
   & dt.blacklight-genre_ssim,
   & dt.blacklight-pub_date_isi {
     display: none;
+  }
+
+  & dd.blacklight-subject_ssim span {
+    background: $gray-lighter-custom;
+    border-radius: 3px;
+    color: $gray-light;
+    display: inline-block;
+    margin: 0 6px 6px 0;
+    padding: 3px 7px;
+    white-space: nowrap;
+
   }
 }
 

--- a/app/assets/stylesheets/partials/search-results.scss
+++ b/app/assets/stylesheets/partials/search-results.scss
@@ -67,6 +67,13 @@
     margin: 0 0 10px 0;
   }
 
+  & dd.blacklight-subject_ssim span {
+    background: $gray-lighter-custom;
+    border-radius: 3px;
+    margin: 0 5px 0 0;
+    padding: 3px 7px;
+  }
+
   & dd.blacklight-pub_date_isi,
   & dd.blacklight-genre_ssim {
     @include label-tags;

--- a/app/assets/stylesheets/partials/search-results.scss
+++ b/app/assets/stylesheets/partials/search-results.scss
@@ -12,7 +12,7 @@
 }
 
 #sortAndPerPage {
-  border-bottom: 0;
+  border-bottom: 1px dotted #ccc;
   font-size: 14px;
   margin: 0;
   padding-bottom: 10px;
@@ -30,10 +30,9 @@
   margin-bottom: 30px;
 
   & .document {
-    border: 1px dotted #ccc;
-    border-radius: 3px;
+    border-bottom: 1px dotted #ccc;
     margin: 0 0 5px 0;
-    padding: 17px 15px 12px 15px;
+    padding: 15px 0;
   }
 
   & .document-counter {

--- a/app/assets/stylesheets/partials/search-results.scss
+++ b/app/assets/stylesheets/partials/search-results.scss
@@ -31,7 +31,7 @@
 
   & .document {
     border-bottom: 1px dotted #ccc;
-    margin: 0 0 5px 0;
+    margin: 0;
     padding: 15px 0;
   }
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -94,9 +94,7 @@ class CatalogController < ApplicationController
 
     config.add_index_field 'author_ssim',  label: 'Authors',
                                            separator_options: { words_connector: '; ', two_words_connector: '; ', last_word_connector: '; ' }
-    config.add_index_field 'subject_ssim', label: 'Subjects',
-                                           separator_options: { words_connector: ' | ', two_words_connector: ', ', last_word_connector: ' | ' }
-
+    config.add_index_field 'subject_ssim', label: 'Subjects', helper_method: :wrap_in_spans
     config.add_index_field 'pub_date_isi', label: 'Date'
     config.add_index_field 'genre_ssim',   label: 'Type'
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -94,9 +94,9 @@ class CatalogController < ApplicationController
 
     config.add_index_field 'author_ssim',  label: 'Authors',
                                            separator_options: { words_connector: '; ', two_words_connector: '; ', last_word_connector: '; ' }
-    config.add_index_field 'subject_ssim', label: 'Subjects', helper_method: :wrap_in_spans
     config.add_index_field 'pub_date_isi', label: 'Date'
     config.add_index_field 'genre_ssim',   label: 'Type'
+    config.add_index_field 'subject_ssim', label: 'Subjects', helper_method: :wrap_in_spans
 
 
     # :display configuration is for our customized show view, it describes where on the page it should go.

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -19,6 +19,7 @@ module CatalogHelper
     [link_to(url, url)]
   end
 
+  # Combines title and part number for series. Used on item page.
   def combine_title_and_part_number(**options)
     field = options[:field]
     part_number_field = field.gsub('_ssim', '_part_number_ssim')
@@ -34,6 +35,11 @@ module CatalogHelper
 
   def link_value(**options)
     options.fetch(:value, []).map { |v| link_to(v, v) }
+  end
+
+  # Wraps spans around each value.
+  def wrap_in_spans(**options)
+    safe_join(options.fetch(:value, []).map { |v| content_tag(:span, html_escape(v)) })
   end
 
   def get_total_count


### PR DESCRIPTION
Styling for subjects on search results page, gives subjects a tag-like design to make them easier to scan/read. 