### PR TITLE
Adding internal DSL for executing solr queries

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -321,11 +321,10 @@ class CatalogController < ApplicationController
   # Redirect legacy show urls (/catalog, /item) to /doi with the corresponding DOI.
   # If an item with that pid no longer exists raise a Record Not Found error
   def legacy_show
-    solr_params = {
-      qt: 'search', rows: 1,
-      fq: ["has_model_ssim:\"#{ContentAggregator.to_class_uri}\"", "fedora3_pid_ssi:\"#{params[:id]}\""]
-    }
-    solr_response = Blacklight.default_index.search(solr_params)
+    # Search for item with the matching fedora pid.
+    solr_response = AcademicCommons.search do |parameters|
+      parameters.rows(1).aggregators_only.filter('fedora3_pid_ssi', params[:id])
+    end
 
     if solr_response.docs.present?
       redirect_to solr_document_url(solr_response.docs.first.doi), status: :moved_permanently

--- a/lib/academic_commons.rb
+++ b/lib/academic_commons.rb
@@ -11,4 +11,22 @@ module AcademicCommons
       str
     end
   end
+
+  # Returns solr search response. User must provide a block which changes the
+  # SearchParameters object. This method uses Blacklight to conduct a search with
+  # our own parameters. Use this method when retriving records outside of the
+  # typical blacklight controller context. This way, there's a centralized place
+  # to make those request.
+  #
+  # @example
+  #  solr_response = AcademicCommons.search do |parameters|
+  #   parameters.rows(1)
+  #   parameters.aggregators_only
+  #   parameters.filter('fedora3_pid_ssi', 'actest:1')
+  # end
+  def self.search
+    params = SearchParameters.new
+    yield(params)
+    Blacklight.default_index.search(params.to_h)
+  end
 end

--- a/lib/academic_commons/search_parameters.rb
+++ b/lib/academic_commons/search_parameters.rb
@@ -1,0 +1,46 @@
+module AcademicCommons
+  class SearchParameters
+    attr_reader :parameters
+
+    def initialize
+      @parameters = {
+        qt: 'search',
+        fq: []
+      }
+    end
+
+    def q(q)
+      @parameters[:q] = q
+      self
+    end
+
+    def id(id)
+      filter('id', id)
+    end
+
+    def filter(key, value)
+      @parameters[:fq] << "#{key}:\"#{value}\""
+      self
+    end
+
+    def assets_only; end
+
+    def aggregators_only
+      @parameters[:fq] << "has_model_ssim:\"#{ContentAggregator.to_class_uri}\""
+      self
+    end
+
+    def rows(rows)
+      @parameters[:rows] = rows
+      self
+    end
+
+    def member_of(pid); end
+
+    def fedora3_pid(pid); end
+
+    def to_h
+      parameters
+    end
+  end
+end


### PR DESCRIPTION
In AC, we make a lot of queries out to Solr outside of the blacklight controller. I wanted to create a centralized place for all these queries to be generated and executed. Right now this code uses blacklight to do the search queries, and I am okay with that for now, but my hope is that by using one method to make all these requests, if we ever were to move away from blacklight, there would be only one place in the code were we would have to update that. 

I converted one of the queries to use this new class and I wanted to get your options on it. Is there a better way to do this? What other things should I take into consideration?

Another plan I have is to use `SolrDocument#field_semantics`, to map field names like `:title` to their corresponding solr field name.