### PR TITLE
DOI in Asset Download Links

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -59,7 +59,7 @@ class DownloadController < ApplicationController
     if resource_doc.nil?
       render body: nil, status: 404
     else
-      redirect_to asset_download_url(resource_doc.id), status: :moved_permanently
+      redirect_to content_download_url(resource_doc.id), status: :moved_permanently
     end
   end
 

--- a/app/controllers/solr_documents_controller.rb
+++ b/app/controllers/solr_documents_controller.rb
@@ -40,7 +40,7 @@ class SolrDocumentsController < ApplicationController
       aggregator = obj.is_a?(ContentAggregator)
       notify_authors_of_new_item(solr_doc) if aggregator
 
-      location_url = aggregator ? solr_document_url(solr_doc['cul_doi_ssi']) : download_url(obj)
+      location_url = aggregator ? solr_document_url(solr_doc['cul_doi_ssi']) : content_download_url(solr_doc['cul_doi_ssi'])
       response.headers['Location'] = location_url
       render status: :ok, plain: ''
     rescue ActiveFedora::ObjectNotFoundError => e
@@ -81,21 +81,6 @@ class SolrDocumentsController < ApplicationController
   end
 
   private
-
-  def download_url(af_obj)
-    download_params = {
-      block: nil,
-      uri: af_obj.pid,
-      filename: nil,
-      download_method: 'download'
-    }
-    block_ds = af_obj.downloadable_content
-    if block_ds
-      download_params[:block] = block_ds.dsid
-      download_params[:filename] = block_ds.label.blank? ? af_obj.label : block_ds.label
-    end
-    fedora_content_url(download_params)
-  end
 
   # Checks to see if new item notification has been sent to author. If one has
   # already been sent does not sent another one.

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -115,7 +115,7 @@ class SolrDocument
 
   def download_path
     return nil unless asset?
-    Rails.application.routes.url_helpers.asset_download_path(id)
+    Rails.application.routes.url_helpers.content_download_path(id)
   end
 
   def asset?

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -115,11 +115,7 @@ class SolrDocument
 
   def download_path
     return nil unless asset?
-    Rails.application.routes.url_helpers.fedora_content_path(
-      :download, fetch('fedora3_pid_ssi', nil),
-      fetch('downloadable_content_dsid_ssi'),
-      fetch('downloadable_content_label_ss')
-    )
+    Rails.application.routes.url_helpers.asset_download_path(id)
   end
 
   def asset?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,21 +35,21 @@ Rails.application.routes.draw do
     concerns :range_searchable
   end
 
+  # Redirect for old download links
   get '/download/fedora_content/download/:uri/:block/:filename', to: 'download#legacy_fedora_content', as: 'legacy_fedora_content',
     block: /(CONTENT|content)/, uri: /.+/, filename: /.+/
-  match 'doi/*id/download', to: 'download#content', via: :get, as: 'content_download'
 
-
-  # Routes for solr document
+  # Routes for Solr Document using DOI as identifier
+  #
   # Instead of specifying solr routes as:
   #   resources :solr_document, only: [:show], controller: 'catalog', path: 'doi', constraints: { id: /.*/ } do
   #     concerns :exportable
   #   end
   # Specifying routes using glob (*) in id param, this way slashes and period are accepted as part of the id.
-  match 'doi/*id/email', to: 'catalog#email', via: [:get, :post], as: :email_solr_document
-  match 'doi/email',     to: 'catalog#email', via: [:get, :post], as: :email_solr_document_index
-  match 'doi/*id',       to: 'catalog#show',  via: :get,          as: :solr_document
-
+  match 'doi/*id/download', to: 'download#content', via: :get,          as: 'content_download'
+  match 'doi/*id/email',    to: 'catalog#email',    via: [:get, :post], as: :email_solr_document
+  match 'doi/email',        to: 'catalog#email',    via: [:get, :post], as: :email_solr_document_index
+  match 'doi/*id',          to: 'catalog#show',     via: :get,          as: :solr_document
 
   mount Blacklight::Engine => '/'
 
@@ -63,9 +63,6 @@ Rails.application.routes.draw do
   get '/notice_received', to: 'dmcas#index'
 
   resources :email_preferences
-
-
-
 
   get '/download/download_log/:id', to: 'download#download_log', as: 'download_log'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,11 @@ Rails.application.routes.draw do
     concerns :range_searchable
   end
 
+  get '/download/fedora_content/download/:uri/:block/:filename', to: 'download#legacy_fedora_content', as: 'legacy_fedora_content',
+    block: /(CONTENT|content)/, uri: /.+/, filename: /.+/
+  match 'doi/*id/download', to: 'download#content', via: :get, as: 'asset_download'
+
+
   # Routes for solr document
   # Instead of specifying solr routes as:
   #   resources :solr_document, only: [:show], controller: 'catalog', path: 'doi', constraints: { id: /.*/ } do
@@ -44,6 +49,7 @@ Rails.application.routes.draw do
   match 'doi/*id/email', to: 'catalog#email', via: [:get, :post], as: :email_solr_document
   match 'doi/email',     to: 'catalog#email', via: [:get, :post], as: :email_solr_document_index
   match 'doi/*id',       to: 'catalog#show',  via: :get,          as: :solr_document
+
 
   mount Blacklight::Engine => '/'
 
@@ -58,9 +64,8 @@ Rails.application.routes.draw do
 
   resources :email_preferences
 
-  get '/download/fedora_content/:download_method/:uri/:block/:filename', to: 'download#fedora_content', as: 'fedora_content',
-    block: /(DC|CONTENT|content|SOURCE|descMetadata)/,
-    uri: /.+/, filename: /.+/, download_method: /(download|show|show_pretty)/
+
+
 
   get '/download/download_log/:id', to: 'download#download_log', as: 'download_log'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
 
   get '/download/fedora_content/download/:uri/:block/:filename', to: 'download#legacy_fedora_content', as: 'legacy_fedora_content',
     block: /(CONTENT|content)/, uri: /.+/, filename: /.+/
-  match 'doi/*id/download', to: 'download#content', via: :get, as: 'asset_download'
+  match 'doi/*id/download', to: 'download#content', via: :get, as: 'content_download'
 
 
   # Routes for solr document

--- a/spec/apis/solr_documents_controller_spec.rb
+++ b/spec/apis/solr_documents_controller_spec.rb
@@ -34,8 +34,7 @@ describe SolrDocumentsController, type: :controller, integration: true do
       expect(response.status).to be 404
       put :update, params: { id: 'actest:2' }
       ActiveFedora::SolrService.commit # Force commit, since we are not using softCommit
-      expect(response.headers['Location'])
-        .to eql('http://test.host/download/fedora_content/download/actest:2/CONTENT/alice_in_wonderland.pdf')
+      expect(response.headers['Location']).to eql('http://test.host/doi/10.7916/TESTDOC2/download')
     end
     after do
       put :update, params: { id: 'actest:1' }

--- a/spec/controllers/download_controller_spec.rb
+++ b/spec/controllers/download_controller_spec.rb
@@ -9,119 +9,74 @@ RSpec.describe DownloadController, type: :controller do
     end
   end
 
-  describe 'GET fedora_content' do
-    let(:mock_client) { double(HTTPClient, head: mock_head_response)}
-    let(:mock_head_response) { double('headers', status: 200) }
-    let(:mock_solr) { double('Solr') }
+  describe 'GET legacy_fedora_content' do
+    let(:mock_resource) do
+      double(docs: [SolrDocument.new(id: '10.7616/TESTTEST', object_state_ssi: 'A', cul_member_of_ssim: ['info:fedora/parent:id'])])
+    end
 
     before do
-      allow(Blacklight.default_index).to receive(:connection).and_return(mock_solr)
+      allow(Blacklight.default_index).to receive(:search).and_return(mock_resource)
+    end
+
+    it 'redirects to /doi/:doi/download when datastream content' do
+      get :legacy_fedora_content, params: { uri: 'good:id', block: 'content', filename: 'foot.txt' }
+      expect(response).to redirect_to '/doi/10.7616/TESTTEST/download'
+    end
+
+    it 'redirects to /doi/:doi/download when datastream CONTENT' do
+      get :legacy_fedora_content, params: { uri: 'good:id', block: 'CONTENT', filename: 'foot.txt' }
+      expect(response).to redirect_to '/doi/10.7616/TESTTEST/download'
+    end
+  end
+
+  describe 'GET content' do
+    let(:resource_doc)  { SolrDocument.new(id: '10.7616/TESTTEST', object_state_ssi: 'A', cul_member_of_ssim: ['info:fedora/parent:id']) }
+    let(:parent_doc)    { SolrDocument.new(object_state_ssi: 'A') }
+    let(:mock_resource) { double(docs: [resource_doc]) }
+    let(:mock_parent)   { double(docs: [parent_doc]) }
+    let(:mock_client)   { double(HTTPClient, head: mock_head_response) }
+    let(:mock_head_response) { double('headers', status: 200) }
+
+    before do
+      allow(Blacklight.default_index).to receive(:search).and_return(mock_resource, mock_parent)
       controller.instance_variable_set(:@cl, mock_client)
+
+      get :content, params: { id: '10.7616/TESTTEST' }
     end
 
-    context 'when downloading resource' do
-      before do
-        allow(mock_solr).to receive(:get).and_return({'response' => {'docs' => [mock_resource]}}, {'response' => {'docs' => [mock_parent].compact}})
-        get :fedora_content, params: { uri: 'good:id', block: 'content', filename: 'foot.txt', download_method: 'download' }
-      end
+    context 'when resource is active, parent is active' do
+      let(:resource_doc) { SolrDocument.new(fedora3_pid_ssi: 'good:id', object_state_ssi: 'A', cul_member_of_ssim: ['info:fedora/parent:id']) }
+      let(:parent_doc) { SolrDocument.new(object_state_ssi: 'A') }
 
-      context 'resource is active, parent is active' do
-        let(:mock_resource) { { object_state_ssi: 'A', cul_member_of_ssim: ['info:fedora/parent:id'] } }
-        let(:mock_parent) { { object_state_ssi: 'A' } }
-        # it should work
-        it do
-          expect(response.headers['X-Accel-Redirect']).to eql('/repository_download/localhost:8983/fedora/objects/good:id/datastreams/content/content')
-        end
-      end
-
-      context 'resource is inactive, parent is active' do
-        let(:mock_resource) { { object_state_ssi: 'I', cul_member_of_ssim: ['info:fedora/parent:id'] } }
-        let(:mock_parent) { { object_state_ssi: 'A' } }
-        # it should fail
-        it do
-          expect(response.headers['X-Accel-Redirect']).to be_nil
-        end
-      end
-
-      context 'resource is active, parent is inactive' do
-        let(:mock_resource) { { object_state_ssi: 'A', cul_member_of_ssim: ['info:fedora/parent:id'] } }
-        let(:mock_parent) { { object_state_ssi: 'I' } }
-        # it should fail
-        it do
-          expect(response.headers['X-Accel-Redirect']).to be_nil
-        end
-      end
-
-      context 'resource is active, parent is absent' do
-        let(:mock_resource) { { object_state_ssi: 'A', cul_member_of_ssim: ['info:fedora/parent:id'] } }
-        let(:mock_parent) { nil }
-        # it should fail
-        it do
-          expect(response.headers['X-Accel-Redirect']).to be_nil
-        end
-      end
-
-      context 'resource is active, parent is not constituent of AC' do
-        # it should fail
-        #TODO: Implement this test when memberOf: collection3 is replaced with constituentOf
-        pending 'migrations of relationships to Hyacinth standards'
+      it 'returns correct X-Accel-Redirect header' do
+        expect(response.headers['X-Accel-Redirect']).to eql('/repository_download/localhost:8983/fedora/objects/good:id/datastreams/content/content')
       end
     end
 
-    describe 'when retrieving metadata' do
-      let(:response_body) { '<?xml version="1.0" encoding="ISO-8859-1"?>' }
-      let(:mock_head_response) { double('headers', status: 200, header: { 'Content-Type' => 'text/xml' }) }
-      let(:mock_client) { double(HTTPClient, head: mock_head_response, get_content: response_body)}
+    context 'when resource is inactive, parent is active' do
+      let(:resource_doc) { SolrDocument.new(object_state_ssi: 'I', cul_member_of_ssim: ['info:fedora/parent:id']) }
+      let(:parent_doc) { SolrDocument.new(object_state_ssi: 'A') }
 
-      before do
-        allow(mock_solr).to receive(:get).and_return({'response' => {'docs' => [mock_resource]}})
+      it 'returns empty X-Accel-Redirect header' do
+        expect(response.headers['X-Accel-Redirect']).to be_nil
       end
+    end
 
-      context 'from active metadata resource' do
-        context 'with solr document' do
-          let(:mock_resource) { { object_state_ssi: 'A', has_model_ssim: ['info:fedora/ldpd:MODSMetadata'] } }
-          it 'returns metadata' do
-            get :fedora_content, params: { uri: 'good:id', block: 'CONTENT', filename: 'metadata.txt', download_method: 'show_pretty', data: 'meta' }
-            expect(response.headers['Content-Type']).to include 'text/plain'
-          end
-        end
+    context 'when resource is active, parent is inactive' do
+      let(:resource_doc) { SolrDocument.new(object_state_ssi: 'A', cul_member_of_ssim: ['info:fedora/parent:id']) }
+      let(:parent_doc) { SolrDocument.new(object_state_ssi: 'I') }
 
-        context 'without solr document' do
-          before :each do
-            allow(ActiveFedora::Base).to receive(:find).with('good:id').and_return(ActiveFedora::Base.new)
-            allow(ActiveFedora::Base.find('good:id')).to receive(:to_solr).and_return({'has_model_ssim' => 'info:fedora/ldpd:MODSMetadata'})
-          end
-
-          let(:mock_resource) { {} }
-          it 'returns metadata' do
-            get :fedora_content, params: { uri: 'good:id', block: 'CONTENT', filename: 'metadata.txt', download_method: 'show_pretty', data: 'meta' }
-            expect(response.headers['Content-Type']).to include 'text/plain'
-          end
-        end
+      it 'returns empty X-Accel-Redirect header' do
+        expect(response.headers['X-Accel-Redirect']).to be_nil
       end
+    end
 
-      context 'from inactive metadata resource' do
-        let(:mock_resource) { { object_state_ssi: 'I', has_model_ssim: ['info:fedora/ldpd:MODSMetadata'] } }
-        it 'returns metadata' do
-          get :fedora_content, params: { uri: 'good:id', block: 'CONTENT', filename: 'metadata.txt', download_method: 'show_pretty', data: 'meta' }
-          expect(response.headers['Content-Type']).to include 'text/plain'
-        end
-      end
+    context 'when resource is active, parent is absent' do
+      let(:resource_doc) { SolrDocument.new(object_state_ssi: 'A', cul_member_of_ssim: ['info:fedora/parent:id']) }
+      let(:parent_doc) { SolrDocument.new }
 
-      context 'from active parentless object' do
-        let(:mock_resource) { { object_state_ssi: 'A' } }
-        it 'returns metadata' do
-          get :fedora_content, params: { uri: 'good:id', block: 'descMetadata', filename: 'metadata.txt', download_method: 'show_pretty', data: 'meta' }
-          expect(response.headers['Content-Type']).to include 'text/plain'
-        end
-      end
-
-      context 'from inactive parentless object' do
-        let(:mock_resource) { { object_state_ssi: 'I' } }
-        it 'returns metadata' do
-          get :fedora_content, params: { uri: 'good:id', block: 'descMetadata', filename: 'metadata.txt', download_method: 'show_pretty', data: 'meta' }
-          expect(response.headers['Content-Type']).to include 'text/plain'
-        end
+      it 'returns empty X-Accel-Redirect header' do
+        expect(response.headers['X-Accel-Redirect']).to be_nil
       end
     end
   end

--- a/spec/features/item_page_spec.rb
+++ b/spec/features/item_page_spec.rb
@@ -48,8 +48,8 @@ describe 'Item Page', type: :feature do
   end
 
   it 'links to asset downloads' do
-    expect(page).to have_xpath '//a[@href=\'/download/fedora_content/download/actest:2/CONTENT/alice_in_wonderland.pdf\']'
-    expect(page).to have_xpath '//a[@href=\'/download/fedora_content/download/actest:4/content/to_solr.json\']'
+    expect(page).to have_xpath '//a[@href=\'/doi/10.7916/TESTDOC2/download\']'
+    expect(page).to have_xpath '//a[@href=\'/doi/10.7916/TESTDOC4/download\']'
   end
 
   describe 'download links for' do
@@ -81,8 +81,8 @@ describe 'Item Page', type: :feature do
 
     it 'renders additional highwire tags' do
       expect(page).to have_xpath('//head/meta[@name="citation_keywords"][@content="Tea Parties"]', visible: false)
-      expect(page).to have_xpath('//head/meta[@name="citation_pdf_url"][@content="http://www.example.com/download/fedora_content/download/actest:2/CONTENT/alice_in_wonderland.pdf"]', visible: false)
-      expect(page).to have_xpath('//head/meta[@name="citation_pdf_url"][@content="http://www.example.com/download/fedora_content/download/actest:4/content/to_solr.json"]', visible: false)
+      expect(page).to have_xpath('//head/meta[@name="citation_pdf_url"][@content="http://www.example.com/doi/10.7916/TESTDOC2/download"]', visible: false)
+      expect(page).to have_xpath('//head/meta[@name="citation_pdf_url"][@content="http://www.example.com/doi/10.7916/TESTDOC4/download"]', visible: false)
     end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -4,16 +4,13 @@ describe SolrDocument do
   describe '#download_path' do
     let(:document) do
       described_class.new(
-        'id' => 'actest:2', 'fedora3_pid_ssi' => 'actest:2',
-        'active_fedora_model_ssi' => 'GenericResource',
-        'downloadable_content_type_ssi' => 'application/pdf',
-        'downloadable_content_dsid_ssi' => 'CONTENT',
-        'downloadable_content_label_ss' => 'alice_in_wonderland.pdf'
+        'id' => '10.7916/TESTDOC2',
+        'active_fedora_model_ssi' => 'GenericResource'
       )
     end
 
     it 'generates correct download_path' do
-      expect(document.download_path).to eql '/download/fedora_content/download/actest:2/CONTENT/alice_in_wonderland.pdf'
+      expect(document.download_path).to eql '/doi/10.7916/TESTDOC2/download'
     end
   end
 


### PR DESCRIPTION
- Changing download links from `/download/fedora_content/download/:uri/:block/:filename` to `/doi/:id/download`
- Removed ability to download descMetadata, no longer needed in this version of AC
- Providing redirect for old download links