### PR TITLE
Adding partials for text on collections show pages

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -70,6 +70,8 @@ class CollectionsController < ApplicationController
     CONFIG.each do |category, config|
       struct = OpenStruct.new(config)
       struct.url = "/collections/#{category}"
+      struct.top_partial = "#{category}_top"
+      struct.bottom_partial = "#{category}_bottom"
       c[category] = struct
     end
 

--- a/app/views/collections/_doctoraltheses_top.erb
+++ b/app/views/collections/_doctoraltheses_top.erb
@@ -1,0 +1,2 @@
+
+<p>Academic Commons holds the full text of all doctoral theses written since 2011 at Columbia and Teachers College. Some theses from Union Theological Seminary are also available, along with a selection of theses written at Columbia before 2011. You can start exploring theses by selecting one of the doctoral programs below.</p>

--- a/app/views/collections/_journals_bottom.erb
+++ b/app/views/collections/_journals_bottom.erb
@@ -1,0 +1,1 @@
+<p>Many of these journals are published in partnership with the Columbia University Libraries. If you are interested in starting a journal or migrating your journal to a new publishing platform, contact the Libraries journal publishing program at xxx@columbia.edu.</p>

--- a/app/views/collections/_journals_top.erb
+++ b/app/views/collections/_journals_top.erb
@@ -1,0 +1,1 @@
+<p>Academic Commons hosts the partial or complete archives of the Columbia-based journals listed below. Select a journal title to start browsing. </p>

--- a/app/views/collections/show.erb
+++ b/app/views/collections/show.erb
@@ -1,7 +1,15 @@
 <h1><%= @category.title %></h1>
 
+<% if lookup_context.exists?(@category.top_partial, ['collections'], true) %>
+   <%= render @category.top_partial %>
+<% end %>
+
 <ul>
   <% @collections.each do |collection| %>
     <li><%= link_to collection.label, collection.search_url %> (<%= collection.count %>)</li>
   <% end %>
 </ul>
+
+<% if lookup_context.exists?(@category.bottom_partial, ['collections'], true) %>
+   <%= render @category.bottom_partial %>
+<% end %>


### PR DESCRIPTION
Partials for text at the top or bottom of a category page can be added to views/collections. For top partial: {category_id}_top, for bottom partial {category_id}_bottom.