### PR TITLE
ACHYDRA-596

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -35,12 +35,14 @@ class CollectionsController < ApplicationController
     }
   }.freeze
 
-  # GET /collections
+  # GET /explore
+  # NB custom resource path for collections
   def index
     @categories = collections_config.values
   end
 
-  # GET /collections/:category_id
+  # GET /explore/:category_id
+  # NB custom resource path for collections
   def show
     # Render 404 if category_id not valid
     raise(ActionController::RoutingError, 'not found') unless valid_category?(params[:category_id])
@@ -76,7 +78,7 @@ class CollectionsController < ApplicationController
 
     CONFIG.each do |category, config|
       struct = OpenStruct.new(config)
-      struct.url = "/collections/#{category}"
+      struct.url = collection_path(category_id: category)
       struct.top_partial = "#{category}_top"
       struct.bottom_partial = "#{category}_bottom"
       c[category] = struct

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -24,7 +24,7 @@
     <div class="<%= container_classes %>">
       <ul class="nav navbar-nav about-links">
         <li><%= link_to t('blacklight.header_links.about'), about_path, 'aria-label': 'About Academic Commons' %></li>
-        <li><%= link_to t('blacklight.header_links.collections'), '/collections/' %></li>
+        <li><%= link_to t('blacklight.header_links.collections'), collections_path %></li>
       </ul>
       <ul class="nav navbar-nav navbar-right user-links">
         <%= render :partial=>'/user_util_links' %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -10,7 +10,7 @@ en:
 
     header_links:
       about: 'About'
-      collections: 'Collections'
+      collections: 'Explore'
       credits: 'Credits'
       developers: 'Developers'
       faq: 'FAQ'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
   mount API => '/'
 
   # Collections routes
-  resources :collections, only: [:index, :show], param: 'category_id'
+  resources :collections, only: [:index, :show], param: 'category_id', path: 'explore'
 
   # Blacklight routes
   concern :searchable, Blacklight::Routes::Searchable.new

--- a/spec/features/explore_spec.rb
+++ b/spec/features/explore_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Explore', type: :feature do
+  # the /explore URL is a custom path for the collections resource controller
+  before { visit collections_path }
+
+  it 'renders the CUL header' do
+    expect(page).to have_css('div.cul-banner', text: 'Columbia University Libraries')
+  end
+
+  CollectionsController::CONFIG.each do |category_id, opts|
+    it "links to the #{opts[:title]} page" do
+      # this needs to look for a link by href
+      expect(page).to have_css("a[href=\"/explore/#{category_id}\"]")
+      find(:css, "a[href=\"/explore/#{category_id}\"]").click
+      expect(page).to have_css 'h1', text: opts[:title]
+    end
+  end
+end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -19,6 +19,12 @@ describe 'Homepage', type: :feature do
     expect(page).to have_css 'h3', text: 'Enhanced discoverability'
   end
 
+  it 'links to the explore page' do
+    within('.about-links') do
+      expect(page).to have_link('Explore', href: '/explore')
+    end
+  end
+
   it 'links to the upload page' do
     # this needs to look for a link by href
     expect(page).to have_css('a[href="/upload"]')


### PR DESCRIPTION
Change the path for the collections resource to "explore"
This change should leave all the path helper and partial names intact
It adds a feature spec for the collection category pages & changes the label for the link in blacklight.en.yml