### PR TITLE
ACHYDRA-614

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -23,8 +23,8 @@ class CollectionsController < ApplicationController
       },
       facet: 'department_ssim'
     },
-    series: {
-      title: 'Series',
+    producedatcolumbia: {
+      title: 'Produced at Columbia',
       summary: 'Browse series of working papers, event videos, and technical reports created by Columbia-affiliated departments and centers.',
       facet: 'series_ssim'
     },

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -20,4 +20,4 @@ after 'deploy:restart', 'resque:restart'
 
 server "cdrs-nginx-#{fetch(:stage)}1.cul.columbia.edu", user: fetch(:remote_user), roles: %w(app db web)
 # In test/prod, deploy from release tags; most recent version is default
-ask :branch, proc { `git tag --sort=version:refname`.split("\n").last }
+ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp

--- a/config/emails.yml
+++ b/config/emails.yml
@@ -17,7 +17,9 @@ test: *local
 # Emails for deployed dev/test environments.
 deployed: &deployed
   mail_deliverer: ac@columbia.edu
-  administrative_notifications: cmg2228@columbia.edu
+  administrative_notifications:
+    - ac@columbia.edu
+    - cmg2228@columbia.edu
   error_notifications: cmg2228@columbia.edu
 
 academiccommons_dev: *deployed


### PR DESCRIPTION
- changed explore/series url to explore/producedatcolumbia
- defaulting to branch when deploying to dev
- sending administrative emails to developer and AC staff in dev/test environments