### PR TITLE
ACHYDRA-654

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -25,13 +25,16 @@ class API < Grape::API
                    'records. `/search` results are limited to 100 results per page '\
                    'and only show the most commonly used fields. The `/record` '\
                    'endpoint will display all the fields. Frequent consumers '\
-                   'of this api, may be interested in setting up a `data_feed/`'\
-                   ' for their specific purposes. Data feeds require authentication '\
+                   'of this api may be interested in setting up a `data_feed/` endpoint'\
+                   'for their specific purposes. Data feeds require authentication '\
                    '(via HTTP Token Authentication), but have the benefit of '\
                    'displaying the entire record and not having an upper limit '\
                    'on the number of results displayed.'\
                    "\n\n All endpoints accept `format` as a query parameter to "\
-                   'specify format response instead of accept headers. For example: `format=json`.',
+                   'specify format response instead of accept headers. For example: `format=json`.'\
+                   "\n\n Records return a list of `resource_paths`. `resource_paths` are partial "\
+                   'paths that can be used to create a file download link. Preprend the base url '\
+                   'listed above to the paths in order to generate download links.',
       contact_name: 'Academic Commons Staff',
       contact_email: 'ac@columbia.edu'
     },

--- a/app/api/v1/entities/data_feed_response.rb
+++ b/app/api/v1/entities/data_feed_response.rb
@@ -6,7 +6,7 @@ module V1
       end
 
       expose :records, using: FullRecord do |solr_response, _options|
-        solr_response['response']['docs'].map { |d| SolrDocument.new(d).to_semantic_values }
+        solr_response.docs
       end
     end
   end

--- a/app/api/v1/entities/full_record.rb
+++ b/app/api/v1/entities/full_record.rb
@@ -1,19 +1,16 @@
 module V1
   module Entities
     class FullRecord < ShortRecord
-      expose :columbia_series
-      expose :thesis_advisor
+      expose(:columbia_series, &:columbia_series)
+      expose(:thesis_advisor, &:thesis_advisor)
 
-      with_options(format_with: :singular) do
-        expose :degree_name
-        expose :degree_level
-        expose :degree_grantor
-        expose :degree_discipline
+      expose(:degree_name)       { |r| r.degree_name.first }
+      expose(:degree_level)      { |r| r.degree_level.first }
+      expose(:degree_grantor)    { |r| r.degree_grantor.first }
+      expose(:degree_discipline) { |r| r.degree_discipline.first }
 
-        expose :embargo_end
-
-        expose :notes
-      end
+      expose(:embargo_end, &:embargo_end)
+      expose(:notes)       { |r| r.notes.first }
     end
   end
 end

--- a/app/api/v1/entities/search_response.rb
+++ b/app/api/v1/entities/search_response.rb
@@ -30,7 +30,7 @@ module V1
       end
 
       expose :records, using: ShortRecord do |solr_response, _options|
-        solr_response['response']['docs'].map { |d| SolrDocument.new(d).to_semantic_values }
+        solr_response.docs
       end
 
       expose :facets do |solr_response, _options|

--- a/app/api/v1/entities/short_record.rb
+++ b/app/api/v1/entities/short_record.rb
@@ -1,31 +1,24 @@
 module V1
   module Entities
     class ShortRecord < Grape::Entity
-      format_with(:singular) { |v| v.first }
+      expose(:id)         { |r| r.id }
+      expose(:legacy_id)  { |r| r.legacy_id }
+      expose(:title)      { |r| r.title }
+      expose(:author)     { |r| r.author }
+      expose(:abstract)   { |r| r.abstract }
+      expose(:date)       { |r| r.date.to_s }
+      expose(:department) { |r| r.department }
+      expose(:subject)    { |r| r.subject }
+      expose(:type)       { |r| r.type }
+      expose(:language)   { |r| r.language }
+      expose(:persistent_url) { |r| r.full_doi }
 
-      with_options(format_with: :singular) do
-        expose :id
-        expose :legacy_id
-        expose :title
+      expose(:resource_paths) do |r|
+        r.assets.map { |a| "/doi/#{a.doi}/download" }
       end
 
-      expose :author
-
-      with_options(format_with: :singular) do
-        expose :abstract
-        expose :date
-      end
-
-      expose :department
-      expose :subject
-      expose :type
-      expose :language
-      expose :persistent_url
-
-      with_options(format_with: :singular) do
-        expose :created_at
-        expose :modified_at
-      end
+      expose(:created_at)  { |r| r.created_at }
+      expose(:modified_at) { |r| r.modified_at }
     end
   end
 end

--- a/app/api/v1/entities/short_record.rb
+++ b/app/api/v1/entities/short_record.rb
@@ -14,7 +14,7 @@ module V1
       expose(:persistent_url) { |r| r.full_doi }
 
       expose(:resource_paths) do |r|
-        r.assets.map { |a| "/doi/#{a.doi}/download" }
+        r.assets.map(&:download_path)
       end
 
       expose(:created_at)  { |r| r.created_at }

--- a/app/api/v1/helpers/solr.rb
+++ b/app/api/v1/helpers/solr.rb
@@ -36,7 +36,7 @@ module V1
           solr_params.sort_by SORT_TO_SOLR_SORT.dig(params[:sort], params[:order])
           solr_params.start((params[:page].to_i - 1) * params[:per_page].to_i)
           solr_params.rows params[:per_page].to_i
-          solr_params.aggregators_only
+          solr_params.aggregators_with_assets
 
           if with_facets
             solr_params.facet_by(*FACETS.map { |f| MAP_TO_SOLR_FIELD[f] })
@@ -45,7 +45,8 @@ module V1
 
           solr_params.search_type(params[:search_type]) if params.key?(:search_type)
         end
-      rescue StandardError
+      rescue StandardError => e
+        Rails.logger.error e
         error! 'unexpected error', 500
       end
     end

--- a/app/api/v1/record.rb
+++ b/app/api/v1/record.rb
@@ -5,18 +5,12 @@ module V1
 
     helpers do
       def get_document(doi)
-        connection = AcademicCommons::Utils.rsolr
-        solr_parameters = {
-          rows: 1,
-          fq: [
-            "cul_doi_ssi:\"#{doi}\"",
-            "has_model_ssim:\"#{ContentAggregator.to_class_uri}\""
-          ],
-          fl: '*', # default blacklight solr param
-          qt: 'search' # default blacklight solr param
-        }
-        solr_response = connection.get('select', params: solr_parameters)
-        solr_response['response']['docs'].first
+        response = AcademicCommons.search do |params|
+          params.aggregators_only
+          params.id(doi)
+          params.rows(1)
+        end
+        response.docs.first
       rescue StandardError
         error! 'unexpected error', 500
       end
@@ -32,7 +26,7 @@ module V1
       if record.blank?
         error! 'Record not found', 404
       else
-        present SolrDocument.new(record).to_semantic_values, with: Entities::FullRecord
+        present record.to_semantic_values, with: Entities::FullRecord
       end
     end
   end

--- a/app/api/v1/record.rb
+++ b/app/api/v1/record.rb
@@ -6,7 +6,7 @@ module V1
     helpers do
       def get_document(doi)
         response = AcademicCommons.search do |params|
-          params.aggregators_only
+          params.aggregators_with_assets
           params.id(doi)
           params.rows(1)
         end
@@ -26,7 +26,7 @@ module V1
       if record.blank?
         error! 'Record not found', 404
       else
-        present record.to_semantic_values, with: Entities::FullRecord
+        present record, with: Entities::FullRecord
       end
     end
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -26,12 +26,10 @@ class CatalogController < ApplicationController
     config.navbar.partials.delete(:saved_searches)
     config.navbar.partials.delete(:search_history)
 
-    config.default_solr_params = {
-      qt: 'search',
-      fq: ["has_model_ssim:\"#{ContentAggregator.to_class_uri}\""],
-      rows: 10,
-      fl: '*' # Return all fields
-    }
+    config.default_solr_params = AcademicCommons::SearchParameters.new
+                                                                  .rows(10)
+                                                                  .aggregators_only
+                                                                  .to_h
 
     # solr field configuration for search results/index views
     config.show.title_field = 'title_ssi'
@@ -42,13 +40,11 @@ class CatalogController < ApplicationController
     config.show.partials = [:show] # Removing :show_header partial
 
     # Default values of parameters to send when requesting a single document
-    config.default_document_solr_params = {
-      fq: ["has_model_ssim:\"#{ContentAggregator.to_class_uri}\""]
-      # fl: '*',
-      # facet: false,
-      # rows: 1
-      # q: '{!raw f=id v=$id}'
-    }
+    config.default_document_solr_params = AcademicCommons::SearchParameters.new
+                                                                           .rows(1)
+                                                                           .request_handler('document')
+                                                                           .aggregators_with_assets
+                                                                           .to_h
 
     # solr field configuration for search results/index views
     config.index.title_field = 'title_ssi'

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -72,7 +72,7 @@ class SolrDocument
       super
       # Custom values
       @semantic_value_hash[:identifier] = full_doi
-      @semantic_value_hash[:persistent_url] = full_doi
+      # @semantic_value_hash[:persistent_url] = full_doi
       @semantic_value_hash[:date] = @semantic_value_hash[:date].map(&:to_s)
     end
 
@@ -92,9 +92,14 @@ class SolrDocument
     return @assets if @assets
 
     if free_to_read?(self)
-      item_pid = fetch('fedora3_pid_ssi', nil)
+      # check if solr response already included assets
+      if (asset_response = fetch('assets', nil))
+        @assets = Blacklight::Solr::Response.new({ response: asset_response }, {}).docs
+      else
+        item_pid = fetch('fedora3_pid_ssi', nil)
 
-      @assets = AcademicCommons.search { |p| p.assets_for(item_pid) }.docs
+        @assets = AcademicCommons.search { |p| p.assets_for(item_pid) }.docs
+      end
     else
       @assets = []
     end
@@ -142,5 +147,11 @@ class SolrDocument
 
   def created_at
     to_semantic_values[:created_at].first
+  end
+
+  field_semantics.except(:id).each do |field, solr_key|
+    define_method(field) do
+      solr_key.ends_with?('m') ? fetch(solr_key, []) : fetch(solr_key, nil)
+    end
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -92,18 +92,9 @@ class SolrDocument
     return @assets if @assets
 
     if free_to_read?(self)
-      obj_display = fetch('fedora3_pid_ssi', nil)
+      item_pid = fetch('fedora3_pid_ssi', nil)
 
-      member_search = {
-        qt: 'search',
-        fl: '*',
-        fq: ["cul_member_of_ssim:\"info:fedora/#{obj_display}\"", 'object_state_ssi:A'],
-        rows: 10_000,
-        facet: false
-      }
-      response = Blacklight.default_index.connection.get 'select', params: member_search
-      docs = response['response']['docs']
-      @assets = docs.map { |member| SolrDocument.new(member) }
+      @assets = AcademicCommons.search { |p| p.assets_for(item_pid) }.docs
     else
       @assets = []
     end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -72,7 +72,6 @@ class SolrDocument
       super
       # Custom values
       @semantic_value_hash[:identifier] = full_doi
-      # @semantic_value_hash[:persistent_url] = full_doi
       @semantic_value_hash[:date] = @semantic_value_hash[:date].map(&:to_s)
     end
 
@@ -135,18 +134,6 @@ class SolrDocument
   def degree
     fields = [fetch('degree_name_ssim', nil), fetch('degree_grantor_ssim', nil)].compact
     fields.blank? ? nil : fields.join(', ')
-  end
-
-  def title
-    to_semantic_values[:title].first
-  end
-
-  def genre
-    to_semantic_values[:genre].first
-  end
-
-  def created_at
-    to_semantic_values[:created_at].first
   end
 
   field_semantics.except(:id).each do |field, solr_key|

--- a/app/views/info/developers.html.erb
+++ b/app/views/info/developers.html.erb
@@ -6,8 +6,7 @@
 
 <h3>API</h3>
 <p>The Academic Commons RESTful API can be used to query/search for records. We support JSON responses. Documentation and a GUI can be found at:<br>
-
-<a href="http://petstore.swagger.io/?url=https://academiccommons.columbia.edu/api/v1/swagger_doc">http://petstore.swagger.io/?url=https://academiccommons.columbia.edu/api/v1/swagger_doc</a></p>
+<%= link_to nil, "http://petstore.swagger.io/?url=#{root_url}api/v1/swagger_doc" %></p>
 
 <h3>OAI-PMH</h3>
 <p>Academic Commons supports the <a href="https://www.openarchives.org/OAI/openarchivesprotocol.html">Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH)</a>, version 2.0.
@@ -18,7 +17,7 @@ The base URL is: <%= link_to oai_catalog_url, oai_catalog_url %></p>
 <p>Academic Commons can receive content via <a href="http://swordapp.org/">SWORD deposit</a>. SWORD is best used for recurrent deposits. If you would like to deposit content via SWORD, contact us at <a href="mailto:ac@columbia.edu">ac@columbia.edu</a>.</p>
 
 <h3>Sitemap</h3>
-<p>The sitemap for Academic Commons is regenerated every weekday. <a href="https://academiccommons.columbia.edu/sitemap.xml.gz">https://academiccommons.columbia.edu/sitemap.xml.gz</a></p>
+<p>The sitemap for Academic Commons is regenerated every weekday. <%= link_to nil, "#{root_url}sitemap.xml.gz" %></p>
 
 <h3>Metadata license</h3>
 <p>Academic Commons bibliographic metadata — excluding abstracts, which may be under copyright — is available under a <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons 0 1.0 Universal</a> license.</p>

--- a/app/views/shared/_highwire_press_tags.erb
+++ b/app/views/shared/_highwire_press_tags.erb
@@ -1,28 +1,28 @@
 <% if @document %>
-  <% semantics_hash = @document.to_semantic_values %>
+  <%= highwire_press_tags 'citation_title',            @document.title %>
+  <%= highwire_press_tags 'citation_author',           @document.author %>
+  <%= highwire_press_tags 'citation_publication_date', @document.date %>
+  <%= highwire_press_tags 'citation_date',             @document.date %>
+  <%= highwire_press_tags 'citation_volume',           @document['volume_ssi'] %>
+  <%= highwire_press_tags 'citation_issue',            @document['issue_ssi'] %>
+  <%= highwire_press_tags 'citation_firstpage',        @document['start_page_ssi'] %>
+  <%= highwire_press_tags 'citation_lastpage',         @document['end_page_ssi'] %>
+  <%= highwire_press_tags 'citation_doi',              @document.doi %>
+  <%= highwire_press_tags 'citation_keywords',         @document.subject %>
 
-  <%= highwire_press_tags 'citation_title',            semantics_hash[:title] %>
-  <%= highwire_press_tags 'citation_author',           semantics_hash[:author] %>
-  <%= highwire_press_tags 'citation_publication_date', semantics_hash[:date] %>
-  <%= highwire_press_tags 'citation_date',             semantics_hash[:date] %>
-  <%= highwire_press_tags 'citation_volume',    @document['volume_ssi'] %>
-  <%= highwire_press_tags 'citation_issue',     @document['issue_ssi'] %>
-  <%= highwire_press_tags 'citation_firstpage', @document['start_page_ssi'] %>
-  <%= highwire_press_tags 'citation_lastpage',  @document['end_page_ssi'] %>
-  <%= highwire_press_tags 'citation_doi',       @document.doi %>
-  <%= highwire_press_tags 'citation_keywords',  semantics_hash[:subject] %>
+  <% types = @document.type %>
 
-  <% if semantics_hash[:type].include?('Articles') && semantics_hash[:type].include?('Reviews') %>
+  <% if types.include?('Articles') && types.include?('Reviews') %>
     <%= highwire_press_tags 'citation_journal_title', @document['book_journal_title_ssi'] %>
   <% end %>
 
-  <% if semantics_hash[:type].include?('Chapters (layout features)') %>
+  <% if types.include?('Chapters (layout features)') %>
     <%= highwire_press_tags 'citation_inbook_title', @document['book_journal_title_ssi'] %>
   <% end %>
 
-  <% if semantics_hash[:type].include?('Theses') %>
-    <%= highwire_press_tags 'citation_dissertation_name',        semantics_hash[:degree_name] %>
-    <%= highwire_press_tags 'citation_dissertation_institution', semantics_hash[:degree_grantor] %>
+  <% if types.include?('Theses') %>
+    <%= highwire_press_tags 'citation_dissertation_name',        @document.degree_name %>
+    <%= highwire_press_tags 'citation_dissertation_institution', @document.degree_grantor %>
   <% end %>
 
   <%= highwire_press_tags 'citation_pdf_url',

--- a/app/views/shared/_social_media_tags.erb
+++ b/app/views/shared/_social_media_tags.erb
@@ -7,12 +7,11 @@
 <meta property="og:image:height" content="512" />
 
 <% if @document %>
-  <% semantics_hash = @document.to_semantic_values %>
-  <meta name="description" content="<%= semantics_hash[:abstract].first %>"/>
+  <meta name="description" content="<%= @document.abstract %>"/>
   <meta property="og:url" content="<%= @document.full_doi %>"/>
   <meta property="og:type" content="article" />
-  <meta property="og:title" content="<%= semantics_hash[:title].first %>"/>
-  <meta property="og:description" content="<%= semantics_hash[:abstract].first %>"/>
+  <meta property="og:title" content="<%= @document.title %>"/>
+  <meta property="og:description" content="<%= @document.abstract %>"/>
 <% else %>
   <meta property="og:url" content="<%= request.url %>"/>
   <meta property="og:title" content="<%= render_page_title %>"/>

--- a/app/views/user/my_works.html.erb
+++ b/app/views/user/my_works.html.erb
@@ -16,7 +16,7 @@
   <table class="table small">
   <% @embargoed_works.docs.each do |document| %>
     <tr>
-      <td><%= link_to document.title, solr_document_path(document.to_semantic_values[:id].first) %></td>
+      <td><%= link_to document.title, solr_document_path(document.id) %></td>
     </tr>
   <% end %>
   </table>
@@ -60,7 +60,7 @@
       <% document = item_stats.document %>
         <tr>
           <td>
-            <%= link_to document.title, solr_document_path(document.to_semantic_values[:id].first) %>
+            <%= link_to document.title, solr_document_path(document.id) %>
           </td>
           <td class="center">
             <%= item_stats.get_stat(Statistic::DOWNLOAD, AcademicCommons::Metrics::PERIOD) %>

--- a/lib/academic_commons/search_parameters.rb
+++ b/lib/academic_commons/search_parameters.rb
@@ -87,12 +87,12 @@ module AcademicCommons
     # This method does not filter out embargoed assets. Assets are embargoed at the item level and
     # therefore the embargo status of an item should be checked before using this data.
     def aggregators_with_assets
-      aggegators_only
+      aggregators_only
 
       # Adding subquery for assets
-      filter_list('*', 'assets:[subquery]')
-      @parameters['assets.q'] = '{!terms f=cul_member_of_ssim v=$row.fedora3_uri_ssi}'
-      @parameters['assets.rows'] = MAX_ROWS
+      field_list('*', 'assets:[subquery]')
+      @parameters[:'assets.q'] = '{!terms f=cul_member_of_ssim v=$row.fedora3_uri_ssi}'
+      @parameters[:'assets.rows'] = MAX_ROWS
       self
     end
 

--- a/lib/academic_commons/search_parameters.rb
+++ b/lib/academic_commons/search_parameters.rb
@@ -56,6 +56,11 @@ module AcademicCommons
       self
     end
 
+    def request_handler(handler)
+      @parameters[:qt] = handler
+      self
+    end
+
     def id(id)
       filter('id', id)
       self

--- a/lib/academic_commons/search_parameters.rb
+++ b/lib/academic_commons/search_parameters.rb
@@ -2,6 +2,12 @@ module AcademicCommons
   class SearchParameters
     MAX_ROWS = 100_000
 
+    SEARCH_TYPES = {
+      keyword: {},
+      title: { 'spellcheck.dictionary': 'title', qf: '${title_qf}', pf: '${title_pf}' },
+      subject: { 'spellcheck.dictionary': 'subject', qf: '${subject_qf}', pf: '${subject_pf}' }
+    }.freeze
+
     attr_reader :parameters
 
     def initialize
@@ -49,6 +55,11 @@ module AcademicCommons
       self
     end
 
+    def start(start)
+      @parameters[:start] = start
+      self
+    end
+
     def member_of(pid); end
 
     def fedora3_pid(pid); end
@@ -74,6 +85,12 @@ module AcademicCommons
 
     def sort_by(sort)
       @parameters[:sort] = sort
+      self
+    end
+
+    def search_type(type)
+      raise ArgumentError, 'search type not valid' unless SEARCH_TYPES.key?(type)
+      @parameters.merge!(SEARCH_TYPES[type])
       self
     end
 

--- a/spec/academic_commons/metrics/usage_statistics_spec.rb
+++ b/spec/academic_commons/metrics/usage_statistics_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe AcademicCommons::Metrics::UsageStatistics, integration: true do
         FactoryBot.create(:download_stat)
         FactoryBot.create(:streaming_stat)
 
-        allow(Blacklight.default_index).to receive(:search)
-          .with(solr_params).and_return(solr_response)
+        allow(Blacklight.default_index).to receive(:search).with(any_args).and_call_original
+        allow(Blacklight.default_index).to receive(:search).with(solr_params).and_return(solr_response)
       end
 
       context 'when requesting stats for an author with embargoed material' do
@@ -211,8 +211,8 @@ RSpec.describe AcademicCommons::Metrics::UsageStatistics, integration: true do
       FactoryBot.create(:streaming_stat, at_time: Time.zone.parse('May 3, 2015'))
       FactoryBot.create(:view_stat, at_time: Time.zone.parse('Jan 7, 2017'))
 
-      allow(Blacklight.default_index).to receive(:search)
-        .with(solr_params).and_return(solr_response)
+      allow(Blacklight.default_index).to receive(:search).with(any_args).and_call_original
+      allow(Blacklight.default_index).to receive(:search).with(solr_params).and_return(solr_response)
     end
 
     it 'creates the expected csv' do
@@ -258,8 +258,8 @@ RSpec.describe AcademicCommons::Metrics::UsageStatistics, integration: true do
       FactoryBot.create(:download_stat, at_time: Time.zone.parse('April 2, 2016'))
       FactoryBot.create(:streaming_stat, at_time: Time.zone.parse('May 3, 2015'))
 
-      allow(Blacklight.default_index).to receive(:search)
-        .with(solr_params).and_return(solr_response)
+      allow(Blacklight.default_index).to receive(:search).with(any_args).and_call_original
+      allow(Blacklight.default_index).to receive(:search).with(solr_params).and_return(solr_response).once
     end
 
     it 'creates the expected csv' do
@@ -283,6 +283,7 @@ RSpec.describe AcademicCommons::Metrics::UsageStatistics, integration: true do
       FactoryBot.create(:download_stat, at_time: Time.zone.parse('April 2, 2016'))
       FactoryBot.create(:streaming_stat, at_time: Time.zone.parse('May 3, 2015'))
 
+      allow(Blacklight.default_index).to receive(:search).with(any_args).and_call_original
       allow(Blacklight.default_index).to receive(:search)
         .with(solr_params).and_return(solr_response)
     end

--- a/spec/api/v1/data_feed_spec.rb
+++ b/spec/api/v1/data_feed_spec.rb
@@ -96,7 +96,8 @@ describe 'GET /api/v1/data_feed/:key', type: :request do
                   'docs' => [
                     {
                       'id' => '10.7916/D8WS9155',
-                      'cul_doi_ssi' => '10.7916/D8WS9155'
+                      'cul_doi_ssi' => '10.7916/D8WS9155',
+                      'active_fedora_model_ssi' => 'GenericResource'
                     }
                   ]
                 }

--- a/spec/api/v1/data_feed_spec.rb
+++ b/spec/api/v1/data_feed_spec.rb
@@ -53,12 +53,11 @@ describe 'GET /api/v1/data_feed/:key', type: :request do
     end
 
     context 'if records match feed' do
-      let(:connection) { double }
       let(:parameters) do
         {
           q: nil, sort: nil, start: 0, rows: 100_000,
-          fq: ["has_model_ssim:\"#{ContentAggregator.to_class_uri}\"", 'genre_ssim:"Theses"', 'degree_level_name_ssim:"Master\'s"'],
-          fl: '*', qt: 'search'
+          fq: ['genre_ssim:"Theses"', 'degree_level_name_ssim:"Master\'s"', "has_model_ssim:\"#{ContentAggregator.to_class_uri}\""],
+          qt: 'search'
         }
       end
 
@@ -126,12 +125,8 @@ describe 'GET /api/v1/data_feed/:key', type: :request do
         }
       end
 
-      before do
-        allow(AcademicCommons::Utils).to receive(:rsolr).and_return(connection)
-      end
-
       it 'returns matching records' do
-        allow(connection).to receive(:get).with('select', params: parameters).and_return(solr_response)
+        allow(Blacklight.default_index).to receive(:search).with(parameters).and_return(solr_response)
 
         get '/api/v1/data_feed/masters', headers: headers
 

--- a/spec/api/v1/data_feed_spec.rb
+++ b/spec/api/v1/data_feed_spec.rb
@@ -57,12 +57,13 @@ describe 'GET /api/v1/data_feed/:key', type: :request do
         {
           q: nil, sort: nil, start: 0, rows: 100_000,
           fq: ['genre_ssim:"Theses"', 'degree_level_name_ssim:"Master\'s"', "has_model_ssim:\"#{ContentAggregator.to_class_uri}\""],
-          qt: 'search'
+          qt: 'search', fl: '*,assets:[subquery]',
+          'assets.q': '{!terms f=cul_member_of_ssim v=$row.fedora3_uri_ssi}', 'assets.rows': 100_000
         }
       end
 
       let(:solr_response) do
-        {
+        Blacklight::Solr::Response.new({
           'response' => {
             'numFound' => 1,
             'docs' => [
@@ -70,7 +71,8 @@ describe 'GET /api/v1/data_feed/:key', type: :request do
                 'id' => '10.7916/D8WS9153',
                 'record_creation_dtsi' => '2011-02-25T18:57:00Z',
                 'record_change_dtsi' => '2011-02-25T18:57:00Z',
-                'language_ssim' => 'English',
+                'object_state_ssi' => 'A',
+                'language_ssim' => ['English'],
                 'cul_doi_ssi' => '10.7916/D8WS9153',
                 'fedora3_pid_ssi' => 'actest:9',
                 'title_ssi' => 'The Warburg effect and its role in cancer detection and therapy',
@@ -87,11 +89,21 @@ describe 'GET /api/v1/data_feed/:key', type: :request do
                 'degree_discipline_ssim' => ['Biotechnology'],
                 'notes_ssim' => ['M.S. Columbia University'],
                 'free_to_read_start_date_ssi' => '2018-01-01',
-                'thesis_advisor_ssim' => ['Smith, John']
+                'thesis_advisor_ssim' => ['Smith, John'],
+                'assets' => {
+                  'numFound' => 1,
+                  'start' => 0,
+                  'docs' => [
+                    {
+                      'id' => '10.7916/D8WS9155',
+                      'cul_doi_ssi' => '10.7916/D8WS9155'
+                    }
+                  ]
+                }
               }
             ]
           }
-        }
+        }, {})
       end
 
       let(:json_response) do
@@ -110,6 +122,7 @@ describe 'GET /api/v1/data_feed/:key', type: :request do
               'type' => ['Theses'],
               'language' => ['English'],
               'persistent_url' => 'https://doi.org/10.7916/D8WS9153',
+              'resource_paths' => ['/doi/10.7916/D8WS9155/download'],
               'created_at' => '2011-02-25T18:57:00Z',
               'modified_at' => '2011-02-25T18:57:00Z',
               'columbia_series' => [],

--- a/spec/api/v1/record_spec.rb
+++ b/spec/api/v1/record_spec.rb
@@ -23,6 +23,7 @@ describe 'GET /api/v1/record/doi/:doi', type: :request do
         'modified_at' => '2017-09-14T16:48:05Z',
         'notes' => nil,
         'persistent_url' => 'https://doi.org/10.7916/ALICE',
+        'resource_paths' => ['/doi/10.7916/TESTDOC2/download', '/doi/10.7916/TESTDOC4/download'],
         'subject' => ['Tea Parties', 'Wonderland', 'Rabbits', 'Magic', 'Nonsense literature', 'Bildungsromans'],
         'thesis_advisor' => [],
         'title' => 'Alice\'s Adventures in Wonderland',

--- a/spec/api/v1/search_spec.rb
+++ b/spec/api/v1/search_spec.rb
@@ -2,17 +2,14 @@ require 'rails_helper'
 
 describe 'GET /api/v1/search', type: :request do
   let(:connection) { double }
-  let(:empty_response) { { 'response' => { 'docs' => [] } } }
+  let(:empty_response) { Blacklight::Solr::Response.new({ 'response' => { 'docs' => [] } }, {}) }
   let(:base_parameters) do
     {
-      q: nil, sort: 'score desc, pub_date_isi desc, title_sort asc',
-      start: 0, rows: 25,
-      fq: ['has_model_ssim:"info:fedora/ldpd:ContentAggregator"'],
-      fl: '*', qt: 'search', facet: 'true',
-      'facet.field' => ['author_ssim', 'pub_date_isi', 'department_ssim', 'subject_ssim', 'genre_ssim', 'series_ssim'],
-      'f.author_ssim.limit' => 5, 'f.pub_date_isi.limit' => 5,
-      'f.department_ssim.limit' => 5, 'f.subject_ssim.limit' => 5,
-      'f.genre_ssim.limit' => 5, 'f.series_ssim.limit' => 5
+      qt: 'search', fq: ['has_model_ssim:"info:fedora/ldpd:ContentAggregator"'],
+      rows: 25, q: nil, sort: 'score desc, pub_date_isi desc, title_sort asc',
+      start: 0, facet: true,
+      'facet.field': ['author_ssim', 'pub_date_isi', 'department_ssim', 'subject_ssim', 'genre_ssim', 'series_ssim'],
+      'facet.limit': 5
     }
   end
 
@@ -20,8 +17,7 @@ describe 'GET /api/v1/search', type: :request do
     let(:parameters) { base_parameters.merge(q: 'alice') }
 
     it 'creates correct solr query' do
-      allow(AcademicCommons::Utils).to receive(:rsolr).and_return(connection)
-      expect(connection).to receive(:get).with('select', params: parameters).and_return(empty_response)
+      expect(Blacklight.default_index).to receive(:search).with(parameters).and_return(empty_response)
       get '/api/v1/search?q=alice'
     end
   end
@@ -30,13 +26,12 @@ describe 'GET /api/v1/search', type: :request do
     context 'by departments' do
       let(:parameters) do
         base_parameters.merge(
-          fq: ['has_model_ssim:"info:fedora/ldpd:ContentAggregator"', 'department_ssim:"Computer Science"', 'department_ssim:"Bioinformatics"']
+          fq: ['department_ssim:"Computer Science"', 'department_ssim:"Bioinformatics"', 'has_model_ssim:"info:fedora/ldpd:ContentAggregator"']
         )
       end
 
       it 'creates correct solr query' do
-        allow(AcademicCommons::Utils).to receive(:rsolr).and_return(connection)
-        expect(connection).to receive(:get).with('select', params: parameters).and_return(empty_response)
+        expect(Blacklight.default_index).to receive(:search).with(parameters).and_return(empty_response)
         get '/api/v1/search?department[]=Computer+Science&department[]=Bioinformatics'
       end
     end
@@ -44,13 +39,12 @@ describe 'GET /api/v1/search', type: :request do
     context 'by author' do
       let(:parameters) do
         base_parameters.merge(
-          fq: ['has_model_ssim:"info:fedora/ldpd:ContentAggregator"', 'author_ssim:"Carroll, Lewis"']
+          fq: ['author_ssim:"Carroll, Lewis"', 'has_model_ssim:"info:fedora/ldpd:ContentAggregator"']
         )
       end
 
       it 'creates correct solr query' do
-        allow(AcademicCommons::Utils).to receive(:rsolr).and_return(connection)
-        expect(connection).to receive(:get).with('select', params: parameters).and_return(empty_response)
+        expect(Blacklight.default_index).to receive(:search).with(parameters).and_return(empty_response)
         get '/api/v1/search?author[]=Carroll,+Lewis'
       end
     end
@@ -58,13 +52,12 @@ describe 'GET /api/v1/search', type: :request do
     context 'by author id' do
       let(:parameters) do
         base_parameters.merge(
-          fq: ['has_model_ssim:"info:fedora/ldpd:ContentAggregator"', 'author_uni_ssim:"abc123"']
+          fq: ['author_uni_ssim:"abc123"', 'has_model_ssim:"info:fedora/ldpd:ContentAggregator"']
         )
       end
 
       it 'creates correct solr query' do
-        allow(AcademicCommons::Utils).to receive(:rsolr).and_return(connection)
-        expect(connection).to receive(:get).with('select', params: parameters).and_return(empty_response)
+        expect(Blacklight.default_index).to receive(:search).with(parameters).and_return(empty_response)
         get '/api/v1/search?author_id[]=abc123'
       end
     end
@@ -78,8 +71,7 @@ describe 'GET /api/v1/search', type: :request do
     end
 
     it 'creates correct solr query' do
-      allow(AcademicCommons::Utils).to receive(:rsolr).and_return(connection)
-      expect(connection).to receive(:get).with('select', params: parameters).and_return(empty_response)
+      expect(Blacklight.default_index).to receive(:search).with(parameters).and_return(empty_response)
       get '/api/v1/search?search_type=title'
     end
 
@@ -96,8 +88,7 @@ describe 'GET /api/v1/search', type: :request do
     let(:parameters) { base_parameters.merge(sort: 'title_sort asc, pub_date_isi desc') }
 
     it 'creates correct solr query' do
-      allow(AcademicCommons::Utils).to receive(:rsolr).and_return(connection)
-      expect(connection).to receive(:get).with('select', params: parameters).and_return(empty_response)
+      expect(Blacklight.default_index).to receive(:search).with(parameters).and_return(empty_response)
       get '/api/v1/search?sort=title&order=asc'
     end
 
@@ -114,8 +105,7 @@ describe 'GET /api/v1/search', type: :request do
     let(:parameters) { base_parameters.merge(start: 50) }
 
     it 'creates correct solr query' do
-      allow(AcademicCommons::Utils).to receive(:rsolr).and_return(connection)
-      expect(connection).to receive(:get).with('select', params: parameters).and_return(empty_response)
+      expect(Blacklight.default_index).to receive(:search).with(parameters).and_return(empty_response)
       get '/api/v1/search?page=3'
     end
 
@@ -156,7 +146,7 @@ describe 'GET /api/v1/search', type: :request do
         'facets' => {
           'author' => { 'Carroll, Lewis' => 1, 'Weird Old Guys.' => 1 },
           'date' => { '1865' => 1 }, 'department' => { 'Bucolic Literary Society.' => 1 },
-          'subject' => { 'Bildungsromans' => 1, 'Nonsense literature' => 1, 'Rabbits' => 1, 'Magic' => 1, 'Tea Parties' => 1, 'Wonderland' => 1 },
+          'subject' => { 'Bildungsromans' => 1, 'Nonsense literature' => 1, 'Rabbits' => 1, 'Magic' => 1, 'Tea Parties' => 1 },
           'type' => { 'Articles' => 1 }
         }
       }
@@ -179,8 +169,7 @@ describe 'GET /api/v1/search', type: :request do
     end
 
     it 'creates correct solr query' do # when per_page is something other than the default
-      allow(AcademicCommons::Utils).to receive(:rsolr).and_return(connection)
-      expect(connection).to receive(:get).with('select', params: parameters).and_return(empty_response)
+      expect(Blacklight.default_index).to receive(:search).with(parameters).and_return(empty_response)
       get '/api/v1/search?per_page=50'
     end
   end

--- a/spec/api/v1/search_spec.rb
+++ b/spec/api/v1/search_spec.rb
@@ -7,7 +7,8 @@ describe 'GET /api/v1/search', type: :request do
     {
       qt: 'search', fq: ['has_model_ssim:"info:fedora/ldpd:ContentAggregator"'],
       rows: 25, q: nil, sort: 'score desc, pub_date_isi desc, title_sort asc',
-      start: 0, facet: true,
+      start: 0, fl: '*,assets:[subquery]', 'assets.q': '{!terms f=cul_member_of_ssim v=$row.fedora3_uri_ssi}',
+      'assets.rows': 100_000, facet: true,
       'facet.field': ['author_ssim', 'pub_date_isi', 'department_ssim', 'subject_ssim', 'genre_ssim', 'series_ssim'],
       'facet.limit': 5
     }
@@ -139,6 +140,7 @@ describe 'GET /api/v1/search', type: :request do
             'type' => ['Articles'],
             'language' => ['English'],
             'persistent_url' => 'https://doi.org/10.7916/ALICE',
+            'resource_paths' => ['/doi/10.7916/TESTDOC2/download', '/doi/10.7916/TESTDOC4/download'],
             'created_at' => '2017-09-14T16:31:33Z',
             'modified_at' => '2017-09-14T16:48:05Z'
           }

--- a/spec/controllers/admin/email_author_reports_controller_spec.rb
+++ b/spec/controllers/admin/email_author_reports_controller_spec.rb
@@ -45,6 +45,7 @@ describe Admin::EmailAuthorReportsController, type: :controller do
 
       before do
         FactoryBot.create_list(:view_stat, 5)
+        allow(Blacklight.default_index).to receive(:search).with(any_args).and_call_original
         allow(Blacklight.default_index).to receive(:search).with(all_authors_search).and_return(authors)
         allow(Blacklight.default_index).to receive(:search).with(author_search).and_return(author_docs)
 

--- a/spec/features/myworks_spec.rb
+++ b/spec/features/myworks_spec.rb
@@ -54,7 +54,7 @@ describe 'myworks', type: :feature do
     end
 
     before do
-      allow(Blacklight.default_index).to receive(:search).with(any_args).and_call_original.once
+      allow(Blacklight.default_index).to receive(:search).with(any_args).and_call_original
       allow(Blacklight.default_index).to receive(:search).with(embargoed_solr_params).and_return(solr_response)
       visit myworks_path
     end

--- a/spec/forms/email_author_reports_form_spec.rb
+++ b/spec/forms/email_author_reports_form_spec.rb
@@ -21,8 +21,8 @@ describe EmailAuthorReportsForm, type: :model do
 
     before do
       FactoryBot.create_list(:view_stat, 5)
-      allow(Blacklight.default_index).to receive(:search)
-        .with(author_search).and_return(author_docs)
+      allow(Blacklight.default_index).to receive(:search).with(any_args).and_call_original
+      allow(Blacklight.default_index).to receive(:search).with(author_search).and_return(author_docs)
       EmailAuthorReportsForm.new(params).send_emails
     end
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -130,5 +130,37 @@ describe SolrDocument do
         document.assets
       end
     end
+
+    context 'when assets are already included in solr response' do
+      let(:document) do
+        described_class.new(
+          id: 'test:obj', fedora3_pid_ssi: 'test:obj', object_state_ssi: 'A',
+          free_to_read_start_date_ssi: Date.current.strftime('%Y-%m-%d'),
+          assets: {
+            numFound: 1, start: 0, docs: [
+              {
+                object_state_ssi: 'A',
+                active_fedora_model_ssi: 'GenericResource',
+                id: 'test:asset',
+                rdf_type_ssim: ['http://purl.oclc.org/NET/CUL/Resource'],
+                cc_license_ssim: ['info:fedora/'],
+                has_model_ssim: ['info:fedora/ldpd:GenericResource'],
+                pid: 'test:asset',
+                fedora3_pid_ssi: 'test:asset'
+              }
+            ]
+          }
+        )
+      end
+
+      it 'does not query solr' do
+        expect(Blacklight.default_index).not_to receive(:search).with(any_args)
+        document.assets
+      end
+
+      it 'returns assets' do
+        expect(document.assets.first.id).to eql 'test:asset'
+      end
+    end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -27,14 +27,14 @@ describe SolrDocument do
     context 'defaults to non-active exclusion' do
       let(:expected_params) do
         {
-          qt: 'search', fl: '*',
-          fq: ["cul_member_of_ssim:\"info:fedora/#{document[:fedora3_pid_ssi]}\"", 'object_state_ssi:A'],
-          rows: 10_000, facet: false
+          qt: 'search',
+          fq: ["cul_member_of_ssim:\"info:fedora/#{document[:fedora3_pid_ssi]}\"", 'object_state_ssi:"A"'],
+          rows: 100_000, facet: false
         }
       end
 
       let(:solr_response) do
-        {
+        Blacklight::Solr::Response.new({
           'response' => {
             'docs' => [
               {
@@ -55,12 +55,12 @@ describe SolrDocument do
               }
             ]
           }
-        }
+        }, {})
       end
 
       before do
-        allow(Blacklight.default_index.connection).to receive(:get)
-          .with('select', params: expected_params)
+        allow(Blacklight.default_index).to receive(:search)
+          .with(expected_params)
           .and_return(solr_response)
           .once
       end
@@ -86,7 +86,7 @@ describe SolrDocument do
       end
 
       it 'calls solr with expected params' do
-        expect(Blacklight.default_index.connection).not_to receive(:get)
+        expect(Blacklight.default_index).not_to receive(:search)
         document.assets
       end
     end
@@ -101,7 +101,7 @@ describe SolrDocument do
       end
 
       it 'calls solr with expected params' do
-        expect(Blacklight.default_index.connection).not_to receive(:get)
+        expect(Blacklight.default_index).not_to receive(:search)
         document.assets
       end
     end
@@ -117,15 +117,15 @@ describe SolrDocument do
 
       let(:expected_params) do
         {
-          qt: 'search', fl: '*',
-          fq: ["cul_member_of_ssim:\"info:fedora/#{document[:fedora3_pid_ssi]}\"", 'object_state_ssi:A'],
-          rows: 10_000, facet: false
+          qt: 'search',
+          fq: ["cul_member_of_ssim:\"info:fedora/#{document[:fedora3_pid_ssi]}\"", 'object_state_ssi:"A"'],
+          facet: false, rows: 100_000
         }
       end
 
       it 'calls solr with expected params' do
-        expect(Blacklight.default_index.connection).to receive(:get)
-          .with('select', params: expected_params)
+        expect(Blacklight.default_index).to receive(:search)
+          .with(expected_params)
           .and_return(:empty_response)
         document.assets
       end


### PR DESCRIPTION
- Adding resource links (partial links to assets) to API
- Documenting resource links in API docs
- Using internal search API to query Solr for API endpoint
- Solr document creates instance methods for semantic fields
- Created more efficient query to retrieve items and their related assets at the same time