### PR TITLE
ACHYDRA-731: Handle catalog controller bad request with 400 bad request response

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,10 @@ class CatalogController < ApplicationController
   include BlacklightOaiProvider::Controller
   include BlacklightRangeLimit::ControllerOverride
 
+  rescue_from Blacklight::Exceptions::InvalidRequest do
+    render plain: 'Invalid request.', status: :bad_request
+  end
+
   layout 'catalog'
 
   # rubocop:disable Rails/LexicallyScopedActionFilter

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'catalog controller actions', type: :request do
+  describe '/search' do
+    it 'returns a 200 status when valid search params are supplied' do
+      get '/search?per_page=20&sort=Published+Latest'
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns a 400 status when invalid search params are supplied' do
+      get '/search?per_page=zzz&sort=zzz'
+      expect(response.status).to eq(400)
+    end
+  end
+end


### PR DESCRIPTION
Fixes excessive logging problem for unhandled Blacklight::Exceptions::InvalidRequest errors.