### PR TITLE
ACHYDRA-735 provides alternative text for isPreviousVersionOf and isNewVersionOf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .project
 .bundle
+.bash_profile
 db/*.sqlite3
 db/*.sqlite3-journal
 db/cstore/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 .project
 .bundle
-.bash_profile
 db/*.sqlite3
 db/*.sqlite3-journal
 db/cstore/**
@@ -50,3 +49,4 @@ coverage/*
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.bash_profile

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -33,6 +33,11 @@ module CatalogHelper
       Time.zone.parse(v).strftime('%B %-d, %Y')
     end
   end
+ 
+  # transforms related item label information
+  def related_item_relation_label(related_item)
+    related_item = related_item[:relation_type].sub('isVersionOf', 'Another thing').sub('isNewVersionOf', 'Previous version').sub('isPreviousVersionOf', 'Subsequent version').remove(/^is/).underscore.gsub('_', ' ').upcase_first.concat(':')
+  end
 
   # Wraps spans around each value.
   def wrap_in_spans(**options)

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -33,10 +33,10 @@ module CatalogHelper
       Time.zone.parse(v).strftime('%B %-d, %Y')
     end
   end
- 
+
   # transforms related item label information
   def related_item_relation_label(related_item)
-    related_item = related_item[:relation_type].sub('isVersionOf', 'Another thing').sub('isNewVersionOf', 'Previous version').sub('isPreviousVersionOf', 'Subsequent version').remove(/^is/).underscore.gsub('_', ' ').upcase_first.concat(':')
+    related_item[:relation_type].sub('isNewVersionOf', 'Previous version').sub('isPreviousVersionOf', 'Subsequent version').remove(/^is/).underscore.gsub('_', ' ').upcase_first.concat(':')
   end
 
   # Wraps spans around each value.

--- a/app/views/catalog/_show_related_items.html.erb
+++ b/app/views/catalog/_show_related_items.html.erb
@@ -8,7 +8,7 @@
     <div class="panel-body">
       <dl>
         <% related_items.each do |related_item| -%>
-          <dt><%= related_item[:relation_type].sub('isNewVersionOf', 'Previous version').sub('isPreviousVersionOf', 'Subsequent version').remove(/^is/).underscore.gsub('_', ' ').upcase_first.concat(':') %></dt>
+          <dt><%= related_item_relation_label(related_item) %></dt>
           <dd><%= link_to related_item[:title], related_item[:link], target: '_blank' %></dd>
         <% end %>
       </dl>

--- a/app/views/catalog/_show_related_items.html.erb
+++ b/app/views/catalog/_show_related_items.html.erb
@@ -8,7 +8,7 @@
     <div class="panel-body">
       <dl>
         <% related_items.each do |related_item| -%>
-          <dt><%= related_item[:relation_type].remove(/^is/).underscore.gsub('_', ' ').upcase_first.concat(':') %></dt>
+          <dt><%= related_item[:relation_type].sub('isNewVersionOf', 'Previous version').sub('isPreviousVersionOf', 'Subsequent version').remove(/^is/).underscore.gsub('_', ' ').upcase_first.concat(':') %></dt>
           <dd><%= link_to related_item[:title], related_item[:link], target: '_blank' %></dd>
         <% end %>
       </dl>

--- a/spec/catalog_helper_spec.rb
+++ b/spec/catalog_helper_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe CatalogHelper, :type => :helper do
+  context do
+    before do
+      allow(helper).to receive(:related_item_relation_label).and_return(related_item_relation_label)
+    end
+    let(:document) do
+      {
+        'title_short' => '0123456789abc',
+        'title_long' => '0123456789abcdefghijklmnopqrstuvwxyz',
+        'title_long_array' => ['0123456789abcdefghijklmnopqrstuvwxyz']
+      }
+    end
+    describe '#short_title' do
+      subject { helper.short_title(document) }
+      context "a short title" do
+        let(:document_show_link_field) { 'title_short' }
+        it { is_expected.to eql('0123456789abc') }
+      end
+      context "a long title" do
+        let(:document_show_link_field) { 'title_long' }
+        it { is_expected.to eql('0123456789abcdefghijklmnopq...') }
+      end
+      context "a long title in an array" do
+        let(:document_show_link_field) { 'title_long_array' }
+        it { is_expected.to eql('0123456789abcdefghijklmnopq...') }
+      end
+      context "no title" do
+        let(:document_show_link_field) { 'title_absent' }
+        it { is_expected.to be_nil }
+      end
+    end
+    describe '#url_for_document' do
+      let(:slug) { 'sluggo' }
+      let(:document_show_link_field) { 'title_short' }
+      subject { helper.url_for_document(SolrDocument.new(document)) }
+      context 'with a site result' do
+        let(:document) do
+          {
+            'title_short' => '0123456789abc',
+            'title_long' => '0123456789abcdefghijklmnopqrstuvwxyz',
+            'title_long_array' => ['0123456789abcdefghijklmnopqrstuvwxyz'],
+            'dc_type_ssm' => ['Publish Target'],
+            'slug_ssim' => [slug]
+          }
+        end
+        it { is_expected.to eql('/' + slug) }
+      end
+      context 'with a non-site result' do
+        let(:document) do
+          {
+            'title_short' => '0123456789abc',
+            'title_long' => '0123456789abcdefghijklmnopqrstuvwxyz',
+            'title_long_array' => ['0123456789abcdefghijklmnopqrstuvwxyz'],
+            'dc_type_ssm' => ['Unpublish Target'],
+            'slug_ssim' => [slug]
+          }
+        end
+        # until we configure routes in this helper config
+        it { is_expected.to be_a SolrDocument }
+      end
+      context 'with nil' do
+        subject { helper.url_for_document(nil) }
+        it { is_expected.to be_nil }
+      end
+    end
+  end

--- a/spec/catalog_helper_spec.rb
+++ b/spec/catalog_helper_spec.rb
@@ -1,47 +1,33 @@
-# require 'rails_helper'
-# require 'academic_commons'
-require './helpers/catalog_helper.rb'
+# frozen_string_literal: true
+require 'rails_helper'
 
-describe CatalogHelper, :type => :helper do
-  context do
-    before do
-      allow(helper).to receive(:related_item_relation_label).and_return(related_item_relation_label)
-    end
+describe CatalogHelper, type: :helper do
+  describe '#related_item_relation_label' do
+    subject { helper.related_item_relation_label(document) }
     let(:document) do
       {
-        'related_item_version_of' => (isVersionOf.sub('isVersionOf', 'Another thing')),
-        'related_item_previous_version_of' => (isPreviousVersionOf.sub('isPreviousVersionOf', 'Subsequent version')),
-        'related_item_new_version_of' => (isNewVersionOf.sub('isNewVersionOf', 'Previous version')),
-        'related_item_other' => (isReviewOf.remove(/^is/).underscore.gsub('_', ' ').upcase_first.concat(':'))
+        relation_type: relation_type_value
       }
     end
-    describe '#related_item_version_of' do
-      subject { helper.related_item_version_of(document) }
-      context "a version of" do
-        let(:document_show_link_field) { 'related_item_version_of' }
-        it { is_expected.to eql('Another thing') }
-      end
+
+    context "a version of" do
+      let(:relation_type_value) { 'isVersionOf' }
+      it { is_expected.to eql('Version of:') }
     end
-    describe '#related_item_previous_version_of' do
-      subject { helper.related_item_previous_version_of(document) }
-      context "a previous version of" do
-        let(:document_show_link_field) { 'related_item_previous_version_of' }
-        it { is_expected.to eql('Subsquent version') }
-      end
+
+    context "a previous version of" do
+      let(:relation_type_value) { 'isPreviousVersionOf' }
+      it { is_expected.to eql('Subsequent version:') }
     end
-    describe '#related_item_new_version_of' do
-      subject { helper.related_item_new_version_of(document) }
-      context "a new version of" do
-        let(:document_show_link_field) { 'related_item_new_version_of' }
-        it { is_expected.to eql('Previous version') }
-      end
+
+    context "a new version of" do
+      let(:relation_type_value) { 'isNewVersionOf' }
+      it { is_expected.to eql('Previous version:') }
     end
-    describe '#related_item_other' do
-      subject { helper.related_item_other(document) }
-      context "a review of" do
-        let(:document_show_link_field) { 'related_item_other' }
-        it { is_expected.to eql('Review of') }
-      end        
+
+    context "a review of" do
+      let(:relation_type_value) { 'isReviewOf' }
+      it { is_expected.to eql('Review of:') }
     end
   end
 end

--- a/spec/catalog_helper_spec.rb
+++ b/spec/catalog_helper_spec.rb
@@ -1,4 +1,6 @@
-require 'rails_helper'
+# require 'rails_helper'
+# require 'academic_commons'
+require './helpers/catalog_helper.rb'
 
 describe CatalogHelper, :type => :helper do
   context do
@@ -7,62 +9,39 @@ describe CatalogHelper, :type => :helper do
     end
     let(:document) do
       {
-        'title_short' => '0123456789abc',
-        'title_long' => '0123456789abcdefghijklmnopqrstuvwxyz',
-        'title_long_array' => ['0123456789abcdefghijklmnopqrstuvwxyz']
+        'related_item_version_of' => (isVersionOf.sub('isVersionOf', 'Another thing')),
+        'related_item_previous_version_of' => (isPreviousVersionOf.sub('isPreviousVersionOf', 'Subsequent version')),
+        'related_item_new_version_of' => (isNewVersionOf.sub('isNewVersionOf', 'Previous version')),
+        'related_item_other' => (isReviewOf.remove(/^is/).underscore.gsub('_', ' ').upcase_first.concat(':'))
       }
     end
-    describe '#short_title' do
-      subject { helper.short_title(document) }
-      context "a short title" do
-        let(:document_show_link_field) { 'title_short' }
-        it { is_expected.to eql('0123456789abc') }
-      end
-      context "a long title" do
-        let(:document_show_link_field) { 'title_long' }
-        it { is_expected.to eql('0123456789abcdefghijklmnopq...') }
-      end
-      context "a long title in an array" do
-        let(:document_show_link_field) { 'title_long_array' }
-        it { is_expected.to eql('0123456789abcdefghijklmnopq...') }
-      end
-      context "no title" do
-        let(:document_show_link_field) { 'title_absent' }
-        it { is_expected.to be_nil }
+    describe '#related_item_version_of' do
+      subject { helper.related_item_version_of(document) }
+      context "a version of" do
+        let(:document_show_link_field) { 'related_item_version_of' }
+        it { is_expected.to eql('Another thing') }
       end
     end
-    describe '#url_for_document' do
-      let(:slug) { 'sluggo' }
-      let(:document_show_link_field) { 'title_short' }
-      subject { helper.url_for_document(SolrDocument.new(document)) }
-      context 'with a site result' do
-        let(:document) do
-          {
-            'title_short' => '0123456789abc',
-            'title_long' => '0123456789abcdefghijklmnopqrstuvwxyz',
-            'title_long_array' => ['0123456789abcdefghijklmnopqrstuvwxyz'],
-            'dc_type_ssm' => ['Publish Target'],
-            'slug_ssim' => [slug]
-          }
-        end
-        it { is_expected.to eql('/' + slug) }
+    describe '#related_item_previous_version_of' do
+      subject { helper.related_item_previous_version_of(document) }
+      context "a previous version of" do
+        let(:document_show_link_field) { 'related_item_previous_version_of' }
+        it { is_expected.to eql('Subsquent version') }
       end
-      context 'with a non-site result' do
-        let(:document) do
-          {
-            'title_short' => '0123456789abc',
-            'title_long' => '0123456789abcdefghijklmnopqrstuvwxyz',
-            'title_long_array' => ['0123456789abcdefghijklmnopqrstuvwxyz'],
-            'dc_type_ssm' => ['Unpublish Target'],
-            'slug_ssim' => [slug]
-          }
-        end
-        # until we configure routes in this helper config
-        it { is_expected.to be_a SolrDocument }
+    end
+    describe '#related_item_new_version_of' do
+      subject { helper.related_item_new_version_of(document) }
+      context "a new version of" do
+        let(:document_show_link_field) { 'related_item_new_version_of' }
+        it { is_expected.to eql('Previous version') }
       end
-      context 'with nil' do
-        subject { helper.url_for_document(nil) }
-        it { is_expected.to be_nil }
-      end
+    end
+    describe '#related_item_other' do
+      subject { helper.related_item_other(document) }
+      context "a review of" do
+        let(:document_show_link_field) { 'related_item_other' }
+        it { is_expected.to eql('Review of') }
+      end        
     end
   end
+end


### PR DESCRIPTION
Uses 'sub' to substitute display text for two related items terms. Details for the ticket are here: https://issues.cul.columbia.edu/browse/ACHYDRA-735