### PR TITLE
validate requested sort fields

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1,4 +1,14 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightRangeLimit::RangeLimitBuilder
+
+  # add to the beginning of the processing chain
+  default_processor_chain.unshift(:validate_sort)
+
+  def validate_sort(_solr_parameters)
+    return unless blacklight_params['sort']
+
+    blacklight_params.delete('sort') unless
+      blacklight_config[:sort_fields].dig(blacklight_params['sort'])
+  end
 end

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'catalog controller actions', type: :request do
       expect(response.status).to eq(200)
     end
 
-    it 'returns a 400 status when invalid search params are supplied' do
-      get '/search?per_page=zzz&sort=zzz'
-      expect(response.status).to eq(400)
+    it 'ignores bad sort values' do
+      get '/search?per_page=20&sort=zzz'
+      expect(response.status).to eq(200)
     end
   end
 end


### PR DESCRIPTION
In a follow-up PR, I will be adding a test of SearchBuilder's validate_sort method and I'll add a pending test to validate the per page param.