### PR TITLE
ACHYDRA-761-new-related-items-terms

### DIFF
--- a/app/models/concerns/academic_commons/desc_metadata.rb
+++ b/app/models/concerns/academic_commons/desc_metadata.rb
@@ -17,7 +17,8 @@ module AcademicCommons
       'moving image'                => 'Video',
       'three dimensional object'    => 'Other',
       'software, multimedia'        => 'Software',
-      'mixed material'              => 'Mixed media'
+      'mixed material'              => 'Mixed media',
+      'learning object'             => 'Learning objects'
     }.freeze
     DEGREE_LABELS = {
       '0' => 'Bachelor\'s',

--- a/app/models/concerns/academic_commons/desc_metadata.rb
+++ b/app/models/concerns/academic_commons/desc_metadata.rb
@@ -26,15 +26,25 @@ module AcademicCommons
     }.freeze
     # Related item types should be displayed in this order.
     ORDERED_RELATED_ITEM_TYPES = [
+      'Continues',
+      'IsContinuedBy',
       'isIdenticalTo',
       'isVersionOf',
       'isNewVersionOf',
+      'IsPreprintOf',
       'isPreviousVersionOf',
       'isSupplementedBy',
       'isSupplementTo',
+      'translation',
+      'translationOf',
       'referencedBy',
       'references',
-      'reviewOf'
+      'reviewOf',
+      'IsCompiledBy',
+      'IsDerivedFrom',
+      'hasPart',
+      'partOf',
+      'isSourceOf'
     ].freeze
 
     # Keeping track of multivalued fields.


### PR DESCRIPTION
this branch adds terms from 'related items' controlled vocabulary in hyacinth into ac so that they will display on the ac website if they are present in an item record