### PR TITLE
ACHYDRA-774 Translating Learning Object genre term

### DIFF
--- a/app/models/concerns/academic_commons/desc_metadata.rb
+++ b/app/models/concerns/academic_commons/desc_metadata.rb
@@ -190,7 +190,7 @@ module AcademicCommons
       # SUBJECT
       mods.css('> subject').each do |subject_node|
         attri = subject_node.attributes
-        next unless attri.count.zero? || (attri['authority'] && attri['authority'].value == 'fast')
+        next unless attri.count.zero? || (attri['authority'])
         subject_node.css('topic,title,namePart').each do |topic_node|
           add_field.call 'subject_ssim', topic_node
           add_field.call 'subject_q',    topic_node

--- a/app/models/concerns/academic_commons/desc_metadata.rb
+++ b/app/models/concerns/academic_commons/desc_metadata.rb
@@ -19,6 +19,11 @@ module AcademicCommons
       'software, multimedia'        => 'Software',
       'mixed material'              => 'Mixed media'
     }.freeze
+    
+    GENRE_TYPES = {
+      'learning object'             => 'Learning Objects'
+    }.freeze
+    
     DEGREE_LABELS = {
       '0' => 'Bachelor\'s',
       '1' => 'Master\'s',
@@ -163,7 +168,7 @@ module AcademicCommons
       add_field.call 'publisher_location_ssi', mods.at_css('originInfo > place > placeTerm')
 
       mods.css('genre').each do |genre_node|
-        add_field.call 'genre_ssim',  genre_node.content&.titlecase
+        add_field.call 'genre_ssim',  genre_node.content&.titlecase,      GENRE_TYPES.fetch(genre_node.text, nil)
         add_field.call 'genre_q',     genre_node.content&.titlecase
       end
 

--- a/app/models/concerns/academic_commons/desc_metadata.rb
+++ b/app/models/concerns/academic_commons/desc_metadata.rb
@@ -31,15 +31,25 @@ module AcademicCommons
     }.freeze
     # Related item types should be displayed in this order.
     ORDERED_RELATED_ITEM_TYPES = [
+      'Continues',
+      'IsContinuedBy',
       'isIdenticalTo',
       'isVersionOf',
       'isNewVersionOf',
+      'isPreprintOf',
       'isPreviousVersionOf',
       'isSupplementedBy',
       'isSupplementTo',
+      'translation',
+      'translationOf',
       'referencedBy',
       'references',
-      'reviewOf'
+      'reviewOf',
+      'IsCompiledBy',
+      'IsDerivedFrom',
+      'hasPart',
+      'partOf',
+      'IsSourceOf'
     ].freeze
 
     # Keeping track of multivalued fields.


### PR DESCRIPTION
I misunderstood RESOURCE_TYPES to refer to genres, so my initial adding of the learning object translation didn't work. This is a second attempt with a new GENRE_TYPES that includes learning object and no other terms. As far as I know, there aren't other genre term translations that are done in another part of the codebase.