### PR TITLE
ci error reporting fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,5 +4,5 @@ inherit_gem:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5.3
-  TargetRailsVersion: 5.2.3
+  TargetRubyVersion: 2.7.5
+  TargetRailsVersion: 6.0.4

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gem 'active-fedora', '~> 8.2'
 gem 'addressable'
 gem 'blacklight', '~> 7.25'
 gem 'blacklight_oai_provider'
-gem 'blacklight_range_limit', git: 'https://github.com/JackBlackLight/blacklight_range_limit.git', branch: 'use_blacklight_component'
+gem 'blacklight_range_limit',
+    git: 'https://github.com/JackBlackLight/blacklight_range_limit.git', branch: 'use_blacklight_component'
 gem 'bootsnap'
 gem 'cancancan'
 gem 'cul-ldap'
@@ -63,7 +64,6 @@ group :development, :test do
 
   gem 'byebug'
   gem 'capybara', '~> 3.0'
-  gem 'coveralls', require: false
   gem 'database_cleaner'
   gem 'equivalent-xml'
   gem 'factory_bot_rails'
@@ -72,6 +72,7 @@ group :development, :test do
   gem 'rspec-its'
   gem 'rspec-rails'
   gem 'selenium-webdriver'
+  gem 'simplecov', require: false
   gem 'solr_wrapper', '~> 4.0'
   gem 'webdrivers', '~> 5.2', require: false
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,12 +155,6 @@ GEM
     childprocess (4.1.0)
     chronic (0.10.2)
     concurrent-ruby (1.1.10)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -536,11 +530,12 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sinatra (2.2.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -572,15 +567,10 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stomp (1.4.10)
-    sync (0.5.0)
     temple (0.8.2)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.31.1)
-      sync
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -651,7 +641,6 @@ DEPENDENCIES
   capistrano-resque (~> 0.2.2)
   capistrano-rvm (~> 0.1)
   capybara (~> 3.0)
-  coveralls
   cul-ldap
   cul_omniauth (>= 0.7.0)
   database_cleaner
@@ -685,6 +674,7 @@ DEPENDENCIES
   rubocul (~> 4.0)
   rubyzip
   selenium-webdriver
+  simplecov
   sitemap_generator
   solr_wrapper (~> 4.0)
   spring

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,7 +40,7 @@ set :linked_files, fetch(:linked_files, []).push(
   'public/robots.txt',
 )
 
-set :ssh_options, :forward_agent, true
+set :ssh_options, { forward_agent: true }
 
 # Namespace crontab based on app environment.
 set :whenever_identifier, ->{ fetch(:deploy_name) }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,7 +40,7 @@ set :linked_files, fetch(:linked_files, []).push(
   'public/robots.txt',
 )
 
-set :ssh_options, { :forward_agent => true }
+set :ssh_options, :forward_agent, true
 
 # Namespace crontab based on app environment.
 set :whenever_identifier, ->{ fetch(:deploy_name) }

--- a/spec/academic_commons/metrics/author_affiliation_report_spec.rb
+++ b/spec/academic_commons/metrics/author_affiliation_report_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe AcademicCommons::Metrics::AuthorAffiliationReport do
     end
 
     it 'expected csv' do
-      expect(CSV.parse(subject)[3..-1]).to match expected_csv
+      expect(CSV.parse(subject)[3..]).to match expected_csv
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,15 @@
-# Require simplecov/coveralls before anything else.
 require 'simplecov'
-require 'coveralls'
-Coveralls.wear!('rails')
+SimpleCov.start do
+  add_filter 'spec/rails_helper.rb'
+  add_filter 'spec/spec_helper.rb'
+  add_filter 'app/channels'
+  add_filter 'app/mailers'
+end
 
 # Use both the coveralls formatter (for sending results to coveralls) and the
 # simplecov html output to have a local display of coverage.
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
+  [SimpleCov::Formatter::HTMLFormatter]
 )
 
 SimpleCov.start


### PR DESCRIPTION
ACHYDRA-889: Update ci task to re-raise SystemExit exception (when present) to indicate that the tests have failed in a CI environment

And also:
    - Remove coveralls
    - Fix some rubocop errors
    - Update rubocop expected ruby and rails version

Note: The tests on this branch are failing, but that's intentional because this branch fixes a reporting issue where failing tests were appearing as passing in CI.  This branch is just meant to be merged into the `upgrade_to_blacklight_720` branch, not the `master` branch, so we can fix the tests there before `master` merge.