### PR TITLE
Add tracking code for google analytics 4

### DIFF
--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -5,7 +5,7 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-
     gtag('config', 'UA-10481105-1');
+    gtag('config', 'G-890CVKT79K');
   </script>
 <% end %>


### PR DESCRIPTION
Adds tracking code for our new GA4 account, but retains the old tracking code so we can compare results.