### PR TITLE
Hash subclass for featured search must override #transform_values in modern Blacklight

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -17,11 +17,16 @@ class CatalogController < ApplicationController
     def [](key)
       fs = FeaturedSearch.where(slug: key).includes(:feature_category, :featured_search_values).first
       if fs
-        {
+        self[key] = {
           label: fs.label,
           fq: AcademicCommons::FeaturedSearches.to_fq(fs)
         }
       end
+    end
+
+    # this will otherwise drop default procs and return a base hash
+    def transform_values
+      LazyFeatureQueryFacet.new
     end
   end
 

--- a/spec/academic_commons/metrics/usage_statistics_spec.rb
+++ b/spec/academic_commons/metrics/usage_statistics_spec.rb
@@ -111,13 +111,14 @@ RSpec.describe AcademicCommons::Metrics::UsageStatistics do
   end
 
   describe '.new' do
+    let(:yesterday) { Date.current.in_time_zone - 1.day }
     context 'when requesting usage stats for author' do
       before do
         # Add records for a pid view and download
-        FactoryBot.create(:view_stat, identifier: item_identifier)
-        FactoryBot.create(:view_stat, identifier: item_identifier)
-        FactoryBot.create(:download_stat, identifier: open_asset_identifier)
-        FactoryBot.create(:streaming_stat, identifier: item_identifier)
+        FactoryBot.create(:view_stat, identifier: item_identifier, at_time: yesterday)
+        FactoryBot.create(:view_stat, identifier: item_identifier, at_time: yesterday)
+        FactoryBot.create(:download_stat, identifier: open_asset_identifier, at_time: yesterday)
+        FactoryBot.create(:streaming_stat, identifier: item_identifier, at_time: yesterday)
       end
 
       context 'when requesting stats for an author with embargoed material' do
@@ -138,8 +139,9 @@ RSpec.describe AcademicCommons::Metrics::UsageStatistics do
       end
 
       context 'when request lifetime stats' do
+        let(:decade_ago) { Date.current.in_time_zone - 10.years }
         before do
-          FactoryBot.create(:view_stat, at_time: Date.new(2001, 4, 12).in_time_zone)
+          FactoryBot.create(:view_stat, at_time: decade_ago)
         end
 
         subject(:usage_stats) do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CatalogController, type: :controller do
+  describe 'search_builder' do
+    context 'when featured search requested' do
+      subject(:solr_params) { search_builder.with(user_params).processed_parameters }
+
+      let(:builder_context) { controller }
+      let(:featured_search) { FactoryBot.create(:libraries_featured_search) }
+      let(:featured_search_value) { featured_search.featured_search_values.first }
+      let(:search_builder) { search_service.search_builder }
+      let(:search_service) { controller.search_service }
+      let(:user_params) { { f: { featured_search: [featured_search.slug] } } }
+
+      it 'includes featured search filters' do
+        expect(solr_params[:fq]).to include('department_ssim:("Libraries")')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- lazily evaluated hash should also cache values if found to prevent double db queries
- ACHYDRA-903