### PR TITLE
Add CUL load balancer IP to the set of trusted proxy IPs (for the academiccommons_prod environment)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,10 +72,9 @@ group :development, :test do
   gem 'json_spec'
   gem 'rspec-its'
   gem 'rspec-rails'
-  gem 'selenium-webdriver'
   gem 'simplecov', require: false
   gem 'solr_wrapper', '~> 4.0'
-  gem 'webdrivers', '~> 5.2', require: false
+  gem 'webdrivers', '~> 5.3.0', require: false
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,10 +600,10 @@ GEM
       rack (>= 1.4, < 3.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (5.2.0)
+    webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -679,7 +679,6 @@ DEPENDENCIES
   rspec-rails
   rubocul (~> 4.0)
   rubyzip
-  selenium-webdriver
   simplecov
   sitemap_generator
   solr_wrapper (~> 4.0)
@@ -689,7 +688,7 @@ DEPENDENCIES
   uglifier
   unicode
   voight_kampff
-  webdrivers (~> 5.2)
+  webdrivers (~> 5.3.0)
   webmock
   webpacker (~> 5.4.0)
   whenever

--- a/config/environments/academiccommons_prod.rb
+++ b/config/environments/academiccommons_prod.rb
@@ -39,6 +39,10 @@ AcademicCommons::Application.configure do
   # Specifies the header that your server uses for sending files
   config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
 
+  # Set the CUL load balancer IP as our trusted proxy so that the X-Forwarded-For value set
+  # by the load balancer is whitelisted for use by the request.remote_ip IP-determining mechanism.
+  config.action_dispatch.trusted_proxies = [IPAddr.new('128.59.241.217')]
+
   # Reducing logging in production.
   config.log_level = :warn
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,14 +17,14 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require 'webdrivers/chromedriver'
+require 'webdrivers'
 require 'capybara/rspec'
 require 'equivalent-xml/rspec_matchers'
 
 require 'webmock/rspec'
 WebMock.disable_net_connect!(
   allow_localhost: true,
-  allow: 'chromedriver.storage.googleapis.com'
+  allow: ['chromedriver.storage.googleapis.com', 'googlechromelabs.github.io']
 )
 
 # on-screen widgets will collapse at certain width breakpoints, so feature specs need to define window dimensions

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ require 'equivalent-xml/rspec_matchers'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(
   allow_localhost: true,
-  allow: ['chromedriver.storage.googleapis.com', 'googlechromelabs.github.io']
+  allow: ['chromedriver.storage.googleapis.com', 'googlechromelabs.github.io', 'edgedl.me.gvt1.com']
 )
 
 # on-screen widgets will collapse at certain width breakpoints, so feature specs need to define window dimensions


### PR DESCRIPTION
This will enable the X-Forwarded-For header to be usable by request.remote_ip.