### PR TITLE
Gem update for macos 15 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,7 +613,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode (0.4.4.4)
+    unicode (0.4.4.5)
     unicode-display_width (2.3.0)
     view_component (2.71.0)
       activesupport (>= 5.0.0, < 8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,7 +349,7 @@ GEM
       net-protocol
     net-ssh (7.2.0)
     netrc (0.11.0)
-    nio4r (2.5.8)
+    nio4r (2.7.4)
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)


### PR DESCRIPTION
Updated the versions for the following gems, so that they can be installed with newer mac os versions:
 - unicode
 - noi4r