### PR TITLE
add meta tags to search results pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,16 @@ class ApplicationController < ActionController::Base
     new_user_session_path
   end
 
+  attr_reader :meta_nofollow, :meta_noindex
+
+  def meta_nofollow!
+    @meta_nofollow = true
+  end
+
+  def meta_noindex!
+    @meta_noindex = true
+  end
+
   private
 
   # Redirect to last page a user visited before log in.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,6 +14,19 @@ class CatalogController < ApplicationController
   before_action :set_xrobots_tag_to_none, only: :index
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
+  # TODO: here
+  before_action :meta_nofollow!, only: [:index, :serach, :opensearch, :facet] # many from searchable and range_searchable concerns
+  before_action :meta_noindex!, only: [:index, :serach, :opensearch, :facet] # many from searchable and range_searchable concerns
+  # allow on:
+  #           :advanced_search (just a search form)
+  #           :opensearch (returns json)
+  #           :raw (for one record)
+  #           :track (for one record)
+  #           :facet (rendered onto serach results page)
+  # not sure:
+  #           :suggest_index,
+  #           :range_limit
+  #           :range_limit_panel
   class LazyFeatureQueryFacet < Hash
     def [](key)
       fs = FeaturedSearch.where(slug: key).includes(:feature_category, :featured_search_values).first

--- a/app/views/layouts/catalog.html.erb
+++ b/app/views/layouts/catalog.html.erb
@@ -2,6 +2,7 @@
   <%= render 'shared/google_analytics' %>
   <%= render 'shared/highwire_press_tags' %>
   <%= render 'shared/social_media_tags' %>
+  <%= render 'shared/meta_tags' %>
   <meta name="bitly-verification" content="35191b8f3154"/>
   <meta name="baidu-site-verification" content="vQh9AyuWzB"/>
 <% end %>

--- a/app/views/shared/_meta_tags.html.erb
+++ b/app/views/shared/_meta_tags.html.erb
@@ -1,0 +1,10 @@
+<meta name="hello i am meta tags partial" content="hello"/>
+<% Rails.logger.fatal("in shared view : #{controller.meta_nofollow}") %>
+
+<% if controller.meta_nofollow %>
+    <meta name="robots" content="nofollow" />
+<% else %>
+<% end %>
+<% if controller.meta_noindex %>
+    <meta name="robots" content="noindex" />
+<% end %>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -19,4 +19,12 @@ describe CatalogController, type: :controller do
       end
     end
   end
+
+  describe '#index' do
+    it 'has robots meta tags' do # rubocop:disable RSpec/MultipleExpectations
+      get :index
+      expect(controller.instance_variable_get(:@meta_nofollow)).to be true
+      expect(controller.instance_variable_get(:@meta_noindex)).to be true
+    end
+  end
 end

--- a/spec/features/search_results_page_spec.rb
+++ b/spec/features/search_results_page_spec.rb
@@ -24,6 +24,12 @@ describe 'Search Results Page', type: :feature do
     expect(page).to have_button 'Sort by Published Earliest'
   end
 
+  it 'has robots meta tags' do
+    visit search_catalog_path(q: 'alice')
+    expect(page).to have_xpath("//meta[@name='robots' and @content='noindex']", visible: false)
+    expect(page).to have_xpath("//meta[@name='robots' and @content='noindex']", visible: false)
+  end
+
   context 'when admin logged in' do
     include_context 'admin user for feature'
 


### PR DESCRIPTION
Add <meta> nofollow and noindex tags to index actions.

Ticket: [ACHYDRA-971](https://columbiauniversitylibraries.atlassian.net/browse/ACHYDRA-971)

