### PR TITLE
Update developers.html.erb

### DIFF
--- a/app/views/info/developers.html.erb
+++ b/app/views/info/developers.html.erb
@@ -26,6 +26,7 @@
 <h2 id="oai">OAI-PMH</h2>
 <p>Academic Commons supports the <a href="https://www.openarchives.org/OAI/openarchivesprotocol.html">Open Archives Initiative Protocol for Metadata Harvesting (OAI-PMH)</a>, version 2.0.
 The base URL is: <%= link_to oai_catalog_url, oai_catalog_url %></p>
+<p>Because of strategies employed to combat excessive bot traffic to this website, in order to utilize our OAI-PMH endpoint you may need to work with us to set up a custom user agent. Please email <a href="mailto:ac@columbia.edu">ac@columbia.edu</a> to discuss this approach.</p>
 
 <h2 id="sword">SWORD</h2>
 <p>Academic Commons can receive materials via <a href="http://swordapp.org/">SWORD deposit</a>. SWORD is a protocol that automates the deposit process. SWORD is best used for recurring deposits, such as regular deposits of theses or working papers from Columbia departments and regular deposits of articles from Columbia-affiliated journals. Additionally, while the Academic Commons API does not include POST functionality, SWORD can be used in a similar manner to make deposits to Academic Commons in a more programmatic way.</p>


### PR DESCRIPTION
adds a note to the developer resources page informing those using/those who wish to use the oai-pmh endpoint that they should follow up with DS staff about the custom user agent approach (if blocked by our security measures)