### PR TITLE
[ACHYDRA-971] Add meta nofollow and noindex tags to search results pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,8 @@ class ApplicationController < ActionController::Base
   helper :all # include all helpers, all the time
   helper_method :fedora_config # share some methods w/ views via helpers
 
+  attr_reader :meta_nofollow, :meta_noindex
+
   rescue_from CanCan::AccessDenied do |exception|
     if current_user.nil?
       respond_to do |format|
@@ -31,6 +33,14 @@ class ApplicationController < ActionController::Base
 
   def new_session_path(scope)
     new_user_session_path
+  end
+
+  def meta_nofollow!
+    @meta_nofollow = true
+  end
+
+  def meta_noindex!
+    @meta_noindex = true
   end
 
   private

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -15,6 +15,8 @@ class CatalogController < ApplicationController
   # rubocop:disable Rails/LexicallyScopedActionFilter
   before_action :record_view_stats, only: :show
   before_action :set_xrobots_tag_to_none, only: :index
+  before_action :meta_nofollow!, only: [:index]
+  before_action :meta_noindex!, only: [:index]
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
   class LazyFeatureQueryFacet < Hash

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -25,7 +25,9 @@
 
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
+    <%= render 'shared/meta_tags' %>
   </head>
+
   <body class="<%= render_body_class %>">
     <%= render 'shared/alert_box' %>
     <%= render :partial => 'shared/cul_banner' %>

--- a/app/views/layouts/embed.erb
+++ b/app/views/layouts/embed.erb
@@ -32,6 +32,7 @@
     <%= vite_stylesheet_tag "embed.scss", media: "all" %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
+    <%= render 'shared/meta_tags' %>
   </head>
   <body class="<%= render_body_class %> <%= controller_path.gsub(/_|\//, '-') %> <%= action_name.gsub(/_/, '-') %>">
 

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -2,6 +2,7 @@
   <%= render 'shared/google_analytics' %>
   <%= render 'shared/highwire_press_tags' %>
   <%= render 'shared/social_media_tags' %>
+  <%= render 'shared/meta_tags' %>
   <meta name="bitly-verification" content="35191b8f3154"/>
   <meta name="baidu-site-verification" content="vQh9AyuWzB"/>
 <% end %>

--- a/app/views/shared/_meta_tags.html.erb
+++ b/app/views/shared/_meta_tags.html.erb
@@ -1,0 +1,6 @@
+<% if @meta_nofollow %>
+  <meta name='robots' content='nofollow' />
+<% end %>
+<% if @meta_noindex %>
+  <meta name='robots' content='noindex' />
+<% end %>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -19,4 +19,16 @@ describe CatalogController, type: :controller do
       end
     end
   end
+
+  describe '#index' do
+    it 'sets meta \'robots: nofollow\' tag attributes' do
+      get :index
+      expect(controller.instance_variable_get(:@meta_nofollow)).to be true
+    end
+
+    it 'sets meta \'robots: noindex\' tag attributes' do
+      get :index
+      expect(controller.instance_variable_get(:@meta_noindex)).to be true
+    end
+  end
 end

--- a/spec/features/search_results_page_spec.rb
+++ b/spec/features/search_results_page_spec.rb
@@ -25,6 +25,12 @@ describe 'Search Results Page', type: :feature do
     expect(page).to have_content('No entries found')
   end
 
+  it 'has robots meta tags' do
+    visit search_catalog_path(q: 'alice')
+    expect(page).to have_xpath("//meta[@name='robots' and @content='noindex']", visible: false) # rubocop:disable RSpec/Capybara/VisibilityMatcher
+    expect(page).to have_xpath("//meta[@name='robots' and @content='noindex']", visible: false) # rubocop:disable RSpec/Capybara/VisibilityMatcher
+  end
+
   it 'indicates active search in the form widget' do
     visit search_catalog_path(q: 'alice')
     click_button 'Sort by Best Match'


### PR DESCRIPTION
### [Jira Ticket](https://columbiauniversitylibraries.atlassian.net/browse/ACHYDRA-971)
***

This PR adds meta tags to tell google scrapers not to index or follow links on search results pages.

We provide google a sitemap with all the pages we want indexed, so this prevents unnecessary requests from google's indexing scraper.

We add the 'noindex' and 'nofollow' rules to the following controller action(s):
- catalog#index

We can easily add it to more actions, but this is the only one I could identify as needing it.