### PR TITLE
[ACHYDRA-1058] update FAQ to add data manifest faq and new file

### DIFF
--- a/app/views/info/faq.html.erb
+++ b/app/views/info/faq.html.erb
@@ -196,6 +196,9 @@
 <h3>Can I use Academic Commons as the data repository for my upcoming research project?</h3>
 <p>We welcome research data and are happy to discuss how Academic Commons—or another repository such as Dryad (see below)—can meet your data sharing needs. We strongly encourage you to contact us when you are planning your project, especially if you will be collecting large amounts of data or if you expect to generate large individual data files. Email us at <a href="mailto:ac@columbia.edu">ac@columbia.edu</a>. Note: Academic Commons does not accept data that includes personally identifiable information for human subjects.</p>
 
+<h3>How can I add my data to Academic Commons?</h3>
+<p>Please fill out a <%= link_to "data manifest", "/ac-data-manifest-template.md", download: 'ac-data-manifest-template.md' %> to tell us more about your data and project. If you have questions or need a DOI before you complete your data deposit, contact us at <%= mail_to 'ac@columbia.edu' %>.</p>
+
 <h3>What is Dryad and why should I use it?</h3>
 <p><a href="https://datadryad.org/stash">Dryad</a> is a digital repository dedicated to research data. Columbia affiliates can deposit data in Dryad, and <a href="https://datadryad.org/stash/submission_process#curation">Dryad curators</a> help ensure that your data is well-described and in the best format for sharing. Dryad assigns a <a href="https://www.doi.org/factsheets/DOIKeyFacts.html">DOI</a> to your data and provides long-term storage. For upload size limits and procedures, see the Dryad <a href="https://datadryad.org/stash/submission_process#upload-methods">upload method documentation</a>.</p>
 <p>Upload data to Dryad by first <a href="https://datadryad.org/stash/sessions/choose_login">signing in</a> with an <a href="https://orcid.org/">ORCID ID</a>, then by following instructions on their upload form. Here is <a href="https://datadryad.org/docs/QuickstartGuideToDataSharing.pdf">a guide (PDF)</a> to get you started.</p>

--- a/public/ac-data-manifest-template.md
+++ b/public/ac-data-manifest-template.md
@@ -1,0 +1,81 @@
+# Data Manifest Readme Template
+This readme file was generated on [YYYY-MM-DD] by [NAME].
+
+
+## HUMAN SUBJECT DATA
+Academic Commons does not accept data that includes personally-identifiable information about human subjects.
+<br/>
+<br/>
+I, [NAME], affirm that the data I am depositing to Academic Commons does not include personally-identifiable information about human subjects.
+
+*Please fill out any of the following sections that relate to your dataset. If you have provided this information elsewhere, such as in a data dictionary or the methodology section of your published article, you may direct readers to where the information already exists, and not re-enter it here.*
+  
+## GENERAL INFORMATION
+#### Title:
+#### DOI:
+*Please contact ac@columabi.edu to receive a DOI for your dataset.*
+#### Abstract:
+#### Funding:
+<br/>
+
+#### Contributors:  
+*Please list at least two contributors; you are encouraged to list all contributors.*
+  
+##### Name: 
+##### ORCID: 
+##### [CRediT role](https://credit.niso.org/): 
+##### CRediT URL: 
+##### Email:
+##### Institution: 
+##### Address:  
+<br/>
+  
+##### Name: 
+##### ORCID: 
+##### [CRediT role](https://credit.niso.org/): 
+##### CRediT URL: 
+##### Email:
+##### Institution: 
+##### Address: 
+
+
+## SHARING/ACCESS INFORMATION
+#### License(s)/restriction(s) placed on the data:
+#### Recommended citation for this dataset:
+#### Link(s) to other publicly accessible location(s) of the data:
+#### Link(s) to publication(s) that cite or use the data:
+
+
+## DATA & FILE OVERVIEW
+#### Size of dataset:
+#### Description of the data and file structure, including relationships between files:
+#### File list:
+#### If this is a new version of an existing dataset, please detail how this new version is different:
+
+
+## METHODOLOGICAL INFORMATION
+### Collection
+#### Date of data collection:
+#### Geographic location of data collection:
+#### Environmental/Experimental conditions:
+#### Description of methods used for collection/generation of data:
+#### Link(s)s to any survey used to generate this data:
+#### Sources from which data was derived:
+#### Additional related data collected that was not included in the current data package:
+
+
+### Processing
+#### Methods for processing the data:
+#### Quality-assurance procedures:
+#### Instrument- or software-specific information needed to interpret the data including standards and/or calibration: 
+
+## DATA-SPECIFIC INFORMATION
+#### Number, names, and definitions of variables:
+#### Number of cases/rows:
+#### Variable list:
+#### Missing data codes:
+#### Specialized formats or other abbreviations used:
+
+
+## ATTRIBUTION FOR THIS MANIFEST
+This template was adapted from Cornell University Library's [Readme Template for Data](https://doi.org/10.7298/mhns-zm71.2).


### PR DESCRIPTION
### [Jira Ticket](https://columbiauniversitylibraries.atlassian.net/browse/ACHYDRA-1058)
***

This PR adds a "How can I add my data to Academic Commons?" subsection to the Data Storage part of the FAQ page.

It includes a link to download the markdown template (from the `/public` directory).
The attachment is downloaded as "ac-data-manifest-template.md"

<img width="781" height="453" alt="Screenshot 2026-04-06 at 2 49 28 PM" src="https://github.com/user-attachments/assets/849351c8-4deb-4f4d-9e62-f622e3444d1c" />

