### PR TITLE
[1084] disable turbolinks for featured search card components

### DIFF
--- a/app/views/collections/_value_panels.html.erb
+++ b/app/views/collections/_value_panels.html.erb
@@ -13,7 +13,7 @@
       </div>
       <h3><%= feature.label %></h3>
       <p><%= feature.description %></p>
-      <p><%= link_to("See all #{feature.label} content (#{feature.count} items)", featured_search_url(feature.value), class: "more-results") %></p>
+      <p><%= link_to("See all #{feature.label} content (#{feature.count} items)", featured_search_url(feature.value), class: "more-results", data: { turbo: false }) %></p>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
### [Jira Ticket](https://columbiauniversitylibraries.atlassian.net/browse/ACHYDRA-1084?actionerId=5fca8bdbf2df6c0076faeb98&sourceType=assign): Some Featured Series "see all" links resolve to the bottom of the target page
***

This appears to be an issue with turbo-drive links interacting with the 'scroll-behavior: smooth' CSS style. Disabling turbo drive for these links fixed the issue in Safari and Firefox.

This is currently deployed to [academiccommons-dev](https://academiccommons-dev.library.columbia.edu/) and can be previewed there.