### PR TITLE
Feature/achydra 462 admin token UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,15 @@ name: CI
 
 on:
   push:
-    branches: [ '*' ]
+    branches: ["**"]
 
 jobs:
   ci-rails-app:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.3.8']
-        node: ['20']
+        ruby-version: ["3.3.8"]
+        node: ["20"]
     env:
       RAILS_ENV: test
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
@@ -31,8 +31,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt-hotspot'
-          java-version: '8'
+          distribution: "adopt-hotspot"
+          java-version: "8"
       - name: Set up Node
         uses: actions/setup-node@v3
         with:

--- a/app/controllers/admin/tokens_controller.rb
+++ b/app/controllers/admin/tokens_controller.rb
@@ -13,6 +13,7 @@ module Admin
       redirect_to action: :index
     rescue StandardError
       flash[:error] = 'There was an error deleting this token'
+      redirect_to action: :index
     end
   end
 end

--- a/app/controllers/admin/tokens_controller.rb
+++ b/app/controllers/admin/tokens_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Admin
+  class TokensController < AdminController
+    load_and_authorize_resource
+
+    def index; end
+  end
+end

--- a/app/controllers/admin/tokens_controller.rb
+++ b/app/controllers/admin/tokens_controller.rb
@@ -7,9 +7,8 @@ module Admin
     def index; end
 
     def destroy
-      Rails.logger.debug "DESTROY TOKEN: #{@token}"
       @token.destroy!
-      flash[:success] = 'Token deleted'
+      flash[:success] = 'Token successfully deleted.'
       redirect_to action: :index
     rescue StandardError
       flash[:error] = 'There was an error deleting this token'

--- a/app/controllers/admin/tokens_controller.rb
+++ b/app/controllers/admin/tokens_controller.rb
@@ -5,5 +5,14 @@ module Admin
     load_and_authorize_resource
 
     def index; end
+
+    def destroy
+      Rails.logger.debug "DESTROY TOKEN: #{@token}"
+      @token.destroy!
+      flash[:success] = 'Token deleted'
+      redirect_to action: :index
+    rescue StandardError
+      flash[:error] = 'There was an error deleting this token'
+    end
   end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -5,7 +5,7 @@ class UserController < ApplicationController
 
   def account
     @email_preference = current_user.email_preference
-    @user_api_token = user_api_token || Token.new
+    @user_api_token = user_mcp_token || Token.new
   end
 
   def my_works
@@ -79,7 +79,7 @@ class UserController < ApplicationController
                                              .calculate_period
   end
 
-  def user_api_token
-    Token.find_by(authorizable: current_user, scope: Token::API)
+  def user_mcp_token
+    Token.find_by(authorizable: current_user, scope: Token::MCP)
   end
 end

--- a/app/controllers/users/tokens_controller.rb
+++ b/app/controllers/users/tokens_controller.rb
@@ -16,34 +16,52 @@ class Users::TokensController < ApplicationController
     end
   end
 
-  def flash_message(token, as_of)
-    if token.persisted?
-      newly_created = as_of <= token.created_at
-      newly_created ? 'Successfully created API token.' : 'Request help to refresh API token.'
-    else
-      token.errors.full_messages.to_sentence
-    end
-  end
+  def update
+    old_token = current_user_token
+    old_token.destroy
 
-  def set_flash!(as_of, token)
-    flash_type = token.persisted? ? :success : :error
-    flash_msg = flash_message(token, as_of)
-    flash[flash_type] = flash_msg
+    new_token = current_user_token
+    http_status = new_token.persisted? ? 200 : 500
+
+    respond_to do |f|
+      f.html do
+        set_flash!(new_token, :update)
+        redirect_to account_path
+      end
+      f.json { render json: { message: flash_message(token, :update) }, http_status: http_status }
+    end
   end
 
   # Right now, we create an MCP scoped token by default!
   def create
-    as_of = DateTime.now
-
     token = current_user_token
     http_status = token.persisted? ? 200 : 500
 
     respond_to do |f|
       f.html do
-        set_flash!(as_of, token)
+        set_flash!(token, :create)
         redirect_to account_path
       end
-      f.json { render json: { message: flash_message(token, as_of) }.to_json, status: http_status }
+      f.json { render json: { message: flash_message(token, :create) }, status: http_status }
     end
+  end
+
+  private
+
+  def flash_message(token, action)
+    return token.errors.full_messages.to_sentence unless token.persisted?
+
+    case action
+    when :create
+      'Successfully created API token.'
+    when :update
+      'Successfully refreshed API token.'
+    end
+  end
+
+  def set_flash!(token, action)
+    flash_type = token.persisted? ? :success : :error
+    message = flash_message(token, action)
+    flash[flash_type] = message
   end
 end

--- a/app/controllers/users/tokens_controller.rb
+++ b/app/controllers/users/tokens_controller.rb
@@ -5,9 +5,9 @@ require 'date'
 class Users::TokensController < ApplicationController
   before_action :authenticate_user!, only: :create
 
-  def current_user_token
+  def current_user_token(scope: Token::MCP)
     token_args = {
-      authorizable: current_user, scope: Token::API
+      authorizable: current_user, scope: scope
     }
     Token.find_or_create_by(token_args) do |token|
       token.token = SecureRandom.hex(32)
@@ -31,6 +31,7 @@ class Users::TokensController < ApplicationController
     flash[flash_type] = flash_msg
   end
 
+  # Right now, we create an MCP scoped token by default!
   def create
     as_of = DateTime.now
 

--- a/app/controllers/users/tokens_controller.rb
+++ b/app/controllers/users/tokens_controller.rb
@@ -7,7 +7,7 @@ class Users::TokensController < ApplicationController
 
   def destroy
     Token.find_by!(authorizable: current_user, scope: Token::MCP).destroy!
-    token_response(:success, 'Successfully deleted token.', :ok)
+    token_response(:success, 'Successfully deleted API token.', :ok)
   rescue StandardError
     token_response(:error, 'Was not able to destroy API token.', :internal_server_error)
   end

--- a/app/controllers/users/tokens_controller.rb
+++ b/app/controllers/users/tokens_controller.rb
@@ -12,7 +12,7 @@ class Users::TokensController < ApplicationController
     Token.find_or_create_by(token_args) do |token|
       token.token = SecureRandom.hex(32)
       token.contact_email = current_user.email
-      token.description = "#{current_user.uid} personal api token"
+      token.description = "#{current_user.uid} personal #{scope.upcase} token"
     end
   end
 

--- a/app/controllers/users/tokens_controller.rb
+++ b/app/controllers/users/tokens_controller.rb
@@ -5,6 +5,39 @@ require 'date'
 class Users::TokensController < ApplicationController
   before_action :authenticate_user!, only: :create
 
+  def destroy
+    Token.find_by!(authorizable: current_user, scope: Token::MCP).destroy!
+    token_response(:success, 'Successfully deleted token.', :ok)
+  rescue StandardError
+    token_response(:error, 'Was not able to destroy API token.', :internal_server_error)
+  end
+
+  def update
+    old_token = current_user_token
+    old_token.destroy
+
+    new_token = current_user_token
+    http_status = new_token.persisted? ? 200 : 500
+
+    flash_type = new_token.persisted? ? :success : :error
+    message = flash_message(new_token, :update)
+
+    token_response(flash_type, message, http_status)
+  end
+
+  # Right now, we create an MCP scoped token by default!
+  def create
+    token = current_user_token
+    http_status = token.persisted? ? 200 : 500
+
+    flash_type = token.persisted? ? :success : :error
+    message = flash_message(token, :create)
+
+    token_response(flash_type, message, http_status)
+  end
+
+  private
+
   def current_user_token(scope: Token::MCP)
     token_args = {
       authorizable: current_user, scope: scope
@@ -15,38 +48,6 @@ class Users::TokensController < ApplicationController
       token.description = "#{current_user.uid} personal #{scope.upcase} token"
     end
   end
-
-  def update
-    old_token = current_user_token
-    old_token.destroy
-
-    new_token = current_user_token
-    http_status = new_token.persisted? ? 200 : 500
-
-    respond_to do |f|
-      f.html do
-        set_flash!(new_token, :update)
-        redirect_to account_path
-      end
-      f.json { render json: { message: flash_message(token, :update) }, http_status: http_status }
-    end
-  end
-
-  # Right now, we create an MCP scoped token by default!
-  def create
-    token = current_user_token
-    http_status = token.persisted? ? 200 : 500
-
-    respond_to do |f|
-      f.html do
-        set_flash!(token, :create)
-        redirect_to account_path
-      end
-      f.json { render json: { message: flash_message(token, :create) }, status: http_status }
-    end
-  end
-
-  private
 
   def flash_message(token, action)
     return token.errors.full_messages.to_sentence unless token.persisted?
@@ -59,9 +60,13 @@ class Users::TokensController < ApplicationController
     end
   end
 
-  def set_flash!(token, action)
-    flash_type = token.persisted? ? :success : :error
-    message = flash_message(token, action)
-    flash[flash_type] = message
+  def token_response(flash_type, message, http_status)
+    respond_to do |f|
+      f.html do
+        flash[flash_type] = message
+        redirect_to account_path
+      end
+      f.json { render json: { message: message }, status: http_status }
+    end
   end
 end

--- a/app/javascript/stylesheets/partials/admin.scss
+++ b/app/javascript/stylesheets/partials/admin.scss
@@ -1,5 +1,14 @@
 /* admin */
 
+#api-tokens-table tbody td {
+  vertical-align: middle;
+  text-align: center;
+}
+
+#api-tokens-table thead th {
+  text-align: center;
+}
+
 .admin-container {
   margin: 0;
 }
@@ -10,62 +19,75 @@ p.admin-intro-message {
 }
 
 p.admin-intro-message:before {
-  content: '\2191';
+  content: "\2191";
 }
 
 @include media-breakpoint-up(md) {
-
   p.admin-intro-message:before {
-    content: '\2190';
+    content: "\2190";
   }
 }
 
 .pagination {
   background: white;
   cursor: default;
-  /* self-clearing method: */ }
-  .pagination a, .pagination span, .pagination em {
-    padding: 0.2em 0.5em;
-    display: block;
-    float: left;
-    margin-right: 1px; }
-  .pagination .disabled {
-    color: #999999;
-    border: 1px solid #dddddd; }
-  .pagination .current {
-    font-style: normal;
-    font-weight: bold;
-    background: #2e6ab1;
-    color: white;
-    border: 1px solid #2e6ab1; }
-  .pagination a {
-    text-decoration: none;
-    color: #105cb6;
-    border: 1px solid #9aafe5; }
-    .pagination a:hover, .pagination a:focus {
-      color: #000033;
-      border-color: #000033; }
-  .pagination .page_info {
-    background: #2e6ab1;
-    color: white;
-    padding: 0.4em 0.6em;
-    width: 22em;
-    margin-bottom: 0.3em;
-    text-align: center; }
-    .pagination .page_info b {
-      color: #000033;
-      background: #6aa6ed;
-      padding: 0.1em 0.25em; }
-  .pagination:after {
-    content: ".";
-    display: block;
-    height: 0;
-    clear: both;
-    visibility: hidden; }
-  * html .pagination {
-    height: 1%; }
-  *:first-child + html .pagination {
-    overflow: hidden; }
+  /* self-clearing method: */
+}
+.pagination a,
+.pagination span,
+.pagination em {
+  padding: 0.2em 0.5em;
+  display: block;
+  float: left;
+  margin-right: 1px;
+}
+.pagination .disabled {
+  color: #999999;
+  border: 1px solid #dddddd;
+}
+.pagination .current {
+  font-style: normal;
+  font-weight: bold;
+  background: #2e6ab1;
+  color: white;
+  border: 1px solid #2e6ab1;
+}
+.pagination a {
+  text-decoration: none;
+  color: #105cb6;
+  border: 1px solid #9aafe5;
+}
+.pagination a:hover,
+.pagination a:focus {
+  color: #000033;
+  border-color: #000033;
+}
+.pagination .page_info {
+  background: #2e6ab1;
+  color: white;
+  padding: 0.4em 0.6em;
+  width: 22em;
+  margin-bottom: 0.3em;
+  text-align: center;
+}
+.pagination .page_info b {
+  color: #000033;
+  background: #6aa6ed;
+  padding: 0.1em 0.25em;
+}
+.pagination:after {
+  content: ".";
+  display: block;
+  height: 0;
+  clear: both;
+  visibility: hidden;
+}
+* html .pagination {
+  height: 1%;
+}
+*:first-child + html .pagination {
+  overflow: hidden;
+}
 
 /* admin sidebar */
 
@@ -103,7 +125,6 @@ p.admin-intro-message:before {
 }
 
 @include media-breakpoint-up(md) {
-
   #main-page #dashboard .admin-sidebar {
     border-bottom: 0;
 
@@ -128,7 +149,6 @@ p.admin-intro-message:before {
 }
 
 @include media-breakpoint-up(md) {
-
   #main-page #dashboard .admin-content {
     border-bottom: $border;
     border-left: $border;
@@ -140,7 +160,6 @@ p.admin-intro-message:before {
 /* usage stats */
 
 #main-page .usage-stats {
-
   & ul.two-col {
     border: 1px dotted #ccc;
     border-bottom: 0;
@@ -158,9 +177,7 @@ p.admin-intro-message:before {
 }
 
 @include media-breakpoint-up(md) {
-
   #main-page .usage-stats {
-
     & ul.two-col {
       display: flex;
     }

--- a/app/models/api_client.rb
+++ b/app/models/api_client.rb
@@ -2,4 +2,8 @@
 
 class APIClient < ApplicationRecord
   has_many :tokens, as: :authorizable, dependent: :destroy
+
+  def to_s
+    name.presence || contact_email.presence || 'API Client'
+  end
 end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,7 +1,8 @@
 class Token < ApplicationRecord
   DATAFEED = :data_feed
   API = :api
-  SCOPES = [API, DATAFEED].map(&:to_s).freeze
+  MCP = :mcp
+  SCOPES = [API, DATAFEED, MCP].map(&:to_s).freeze
   AUTHORIZABLE_TYPE_USER = :User
   AUTHORIZABLE_TYPE_API_CLIENT = :APIClient
   AUTHORIZABLE_TYPES = [AUTHORIZABLE_TYPE_USER, AUTHORIZABLE_TYPE_API_CLIENT].map(&:to_s).freeze

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
 
   has_many :agreements, dependent: :destroy
   has_many :deposits,   dependent: :nullify # Keep deposits even if the user has been removed.
+  # TODO : should probably has_many --- if we are going to use API scope tokens...
   has_one :token, as: :authorizable, dependent: :destroy
 
   def self.admins

--- a/app/views/admin/tokens/index.html.erb
+++ b/app/views/admin/tokens/index.html.erb
@@ -1,9 +1,10 @@
-<h2>All Tokens</h2>
+<h2>API Token Management</h2>
 
 <%- if @tokens.empty? %>
   <p>No api tokens</p>
 <%- else %>
-  <table class="table table-striped">
+  <table class="table table-striped" id="api-tokens-table">
+    <caption>API Tokens</caption>
     <thead>
       <tr>
         <th scope="col">#</th>
@@ -11,15 +12,30 @@
         <th scope="col">Contact Email</th>
         <th scope="col">Scope</th>
         <th scope="col">Actions</th>
+        <th scope="col">Token Value</th>
       </tr>
     </thead>
     <tbody>
       <%- @tokens.each_with_index do |token, index| %>
-        <th scope="row"><%= index %></th>
-        <td><%= token.authorizable %></td>
-        <td><%= token.contact_email %></td>
-        <td><%= token.scope.upcase %></td>
-        <td><%= link_to 'Destroy token', admin_token_path(token), class: 'text-danger', data: { turbo_method: :delete, turbo_confirm: "Deleting #{token.scope.upcase} token - Are you sure?" } %></td>
+        <tr >
+          <th scope="row"><%= index %></th>
+          <td><%= token.authorizable %></td>
+          <td><%= token.contact_email %></td>
+          <td><%= token.scope.upcase %></td>
+          <td>
+            <%= button_to 'Delete Token', admin_token_path(token), method: :delete, class: 'btn btn-danger', data: { turbo_method: :delete, turbo_confirm: "Deleting #{token.scope.upcase} token - Are you sure?" } %>
+          </td>
+          <td>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=<%= "#token-value-#{index}" %> aria-expanded="false" aria-controls=<%= "token-value-#{index}" %>>
+              Show Value
+            </button>
+          </td>
+        </tr>
+        <tr class="collapse" id=<%= "token-value-#{index}" %>>
+          <td colspan="6">
+          <code><%= token.token %></code>
+          </td>
+        </tr>
       <%- end %>
     </tbody>
   </table>

--- a/app/views/admin/tokens/index.html.erb
+++ b/app/views/admin/tokens/index.html.erb
@@ -8,6 +8,7 @@
       <tr>
         <th scope="col">#</th>
         <th scope="col">Owner</th>
+        <th scope="col">Contact Email</th>
         <th scope="col">Scope</th>
         <th scope="col">Actions</th>
       </tr>
@@ -15,9 +16,10 @@
     <tbody>
       <%- @tokens.each_with_index do |token, index| %>
         <th scope="row"><%= index %></th>
+        <td><%= token.authorizable %></td>
         <td><%= token.contact_email %></td>
         <td><%= token.scope.upcase %></td>
-        <td><%= link_to 'Destroy token', admin_token_path(token), data: { turbo_method: :delete, turbo_confirm: "Deleting #{token.scope.upcase} token - Are you sure?" } %></td>
+        <td><%= link_to 'Destroy token', admin_token_path(token), class: 'text-danger', data: { turbo_method: :delete, turbo_confirm: "Deleting #{token.scope.upcase} token - Are you sure?" } %></td>
       <%- end %>
     </tbody>
   </table>

--- a/app/views/admin/tokens/index.html.erb
+++ b/app/views/admin/tokens/index.html.erb
@@ -1,0 +1,7 @@
+<h2>All Tokens</h2>
+
+<ul>
+  <%- @tokens.each do |token| %>
+    <li><%= token.scope %></li>
+  <%- end %>
+</ul>

--- a/app/views/admin/tokens/index.html.erb
+++ b/app/views/admin/tokens/index.html.erb
@@ -1,7 +1,25 @@
 <h2>All Tokens</h2>
 
-<ul>
-  <%- @tokens.each do |token| %>
-    <li><%= token.scope %></li>
-  <%- end %>
-</ul>
+<%- if @tokens.empty? %>
+  <p>No api tokens</p>
+<%- else %>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Owner</th>
+        <th scope="col">Scope</th>
+        <th scope="col">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <%- @tokens.each_with_index do |token, index| %>
+        <th scope="row"><%= index %></th>
+        <td><%= token.contact_email %></td>
+        <td><%= token.scope.upcase %></td>
+        <td><%= link_to 'Destroy token', admin_token_path(token), data: { turbo_method: :delete, turbo_confirm: "Deleting #{token.scope.upcase} token - Are you sure?" } %></td>
+      <%- end %>
+    </tbody>
+  </table>
+<%- end %>
+

--- a/app/views/shared/_admin_sidebar.erb
+++ b/app/views/shared/_admin_sidebar.erb
@@ -8,6 +8,7 @@
       <li><%= link_to 'Configure Site Options', edit_admin_site_configuration_path %></li>
       <li><%= link_to 'Self-Deposits', admin_deposits_path %></li>
       <li><%= link_to 'Email Preferences', admin_email_preferences_path %></li>
+      <li><%= link_to 'API Token Management', admin_tokens_path %></li>
     </ul>
     <h4>Participation Agreements</h4>
     <ul>

--- a/app/views/user/account.html.erb
+++ b/app/views/user/account.html.erb
@@ -44,11 +44,12 @@
     </div>
   <% else %>
     <div class="form-group">
-      <%= f.label :token, 'Personal API Token', class: 'control-label' %>
+      <%= f.label :token, 'Personal MCP API Token', class: 'control-label' %>
       <%= f.text_field :token, class: 'form-control', disabled: true %>
     </div>
     <div class="form-group">
       <%= button_to 'Generate new token', user_token_path(current_user), class: 'btn btn-primary', method: :patch, data: { disable_with: 'Regenerating...' } %>
+      <%= button_to 'Delete token', user_token_path(current_user), class: 'btn btn-danger', method: :delete, data: { disable_with: 'Regenerating...' } %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/user/account.html.erb
+++ b/app/views/user/account.html.erb
@@ -47,5 +47,8 @@
       <%= f.label :token, 'Personal API Token', class: 'control-label' %>
       <%= f.text_field :token, class: 'form-control', disabled: true %>
     </div>
+    <div class="form-group">
+      <%= button_to 'Generate new token', user_token_path(current_user), class: 'btn btn-primary', method: :patch, data: { disable_with: 'Regenerating...' } %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/user/account.html.erb
+++ b/app/views/user/account.html.erb
@@ -48,8 +48,8 @@
       <%= f.text_field :token, class: 'form-control', disabled: true %>
     </div>
     <div class="form-group">
-      <%= button_to 'Generate new token', user_token_path(current_user), class: 'btn btn-primary', method: :patch, data: { disable_with: 'Regenerating...' } %>
-      <%= button_to 'Delete token', user_token_path(current_user), class: 'btn btn-danger', method: :delete, data: { disable_with: 'Regenerating...' } %>
+      <%= button_to 'Generate New Token', user_token_path(current_user), class: 'btn btn-primary', method: :patch, data: { disable_with: 'Regenerating...' } %>
+      <%= button_to 'Delete Token', user_token_path(current_user), class: 'btn btn-danger', method: :delete, data: { disable_with: 'Regenerating...' } %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/user/account.html.erb
+++ b/app/views/user/account.html.erb
@@ -36,20 +36,23 @@
     <%= f.submit 'Save', class: 'btn btn-primary', data: { disable_with: 'Saving...' } %>
   </div>
 <% end %>
+
 <h3>API Token</h3>
-<%= form_with model: @user_api_token, url: user_token_path(current_user), method: :post, class: 'form-horizontal ajax-flash-messages', local: true do |f| %>
-  <% if @user_api_token.new_record? %>
+<% if @user_api_token.new_record? %>
+  <%= form_with model: @user_api_token, url: user_token_path(current_user), method: :post, class: 'form-horizontal ajax-flash-messages', local: true do |f| %>
     <div class="form-group">
       <%= f.submit 'Generate Token', class: 'btn btn-primary', data: { disable_with: 'Generating...' } %>
     </div>
-  <% else %>
-    <div class="form-group">
-      <%= f.label :token, 'Personal MCP API Token', class: 'control-label' %>
-      <%= f.text_field :token, class: 'form-control', disabled: true %>
-    </div>
-    <div class="form-group">
-      <%= button_to 'Generate New Token', user_token_path(current_user), class: 'btn btn-primary', method: :patch, data: { disable_with: 'Regenerating...' } %>
-      <%= button_to 'Delete Token', user_token_path(current_user), class: 'btn btn-danger', method: :delete, data: { disable_with: 'Regenerating...' } %>
-    </div>
   <% end %>
+<% else %>
+  <form>
+    <div class="form-group">
+      <label for='mcp-token' class='control-label'>Personal MCP API Token</label>
+      <input id='mcp-token' type="text" class='form-control' disabled value=<%= @user_api_token.token %> />
+    </div>
+  </form>
+  <div class="form-group">
+    <%= button_to 'Generate New Token', user_token_path(current_user), class: 'btn btn-primary mr-3', method: :patch, data: {  turbo_confirm: "Refreshing an API token deletes the current one - are you sure?"  } %>
+    <%= button_to 'Delete Token', user_token_path(current_user), class: 'btn btn-danger', method: :delete, data: { turbo_confirm: "Deleting API token - are you sure?"  } %>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,7 @@ Rails.application.routes.draw do
   get 'account',             to: 'user#account'
   get 'unsubscribe_monthly', to: 'user#unsubscribe_monthly'
   resources :users, only: [:show] do
-    resource :token, only: [:create, :update], module: :users
+    resource :token, only: [:create, :update, :destroy], module: :users
   end
 
   get '/admin',                   to: 'admin#index',                 as: 'admin'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,7 @@ Rails.application.routes.draw do
   get 'account',             to: 'user#account'
   get 'unsubscribe_monthly', to: 'user#unsubscribe_monthly'
   resources :users, only: [:show] do
-    resource :token, only: [:create], module: :users
+    resource :token, only: [:create, :update], module: :users
   end
 
   get '/admin',                   to: 'admin#index',                 as: 'admin'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
     end
     resources :featured_searches, except: :show
     resource :contact_authors, only: [:new, :create]
+    resources :tokens, only: [:index, :edit, :destroy]
   end
 
   # Resque web interface, only administrators have access

--- a/lib/tasks/ac/migrate.rake
+++ b/lib/tasks/ac/migrate.rake
@@ -42,5 +42,12 @@ namespace :ac do
         deposit.save!
       end
     end
+
+    desc 'Migrate API scopes for MCP tokens (API to MCP)'
+    task api_to_mcp_tokens: :environment do
+      Token.where(scope: Token::API) do |token|
+        token.update(scope: Token::MCP)
+      end
+    end
   end
 end

--- a/spec/controllers/admin/tokens_controller_spec.rb
+++ b/spec/controllers/admin/tokens_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::TokensController, type: :controller do
+  # GET /admin/tokens
+  describe 'GET #index' do
+    include_examples 'authorization required' do
+      let(:http_request) { get :index }
+    end
+  end
+
+  # DELETE /admin/token/:token_id
+  describe 'DELETE #destroy' do
+    let(:token) { FactoryBot.create(:token) }
+
+    include_examples 'authorization required', 302 do
+      let(:http_request) { delete :destroy, params: { id: token.id } }
+    end
+  end
+end

--- a/spec/controllers/users/tokens_controller_spec.rb
+++ b/spec/controllers/users/tokens_controller_spec.rb
@@ -17,4 +17,41 @@ RSpec.describe Users::TokensController, type: :controller do
       expect(controller.flash).to be_key('success')
     end
   end
+
+  # PUT/PATCH /users/$uni/api_token
+  describe 'PATCH #update' do
+    before do
+      FactoryBot.create(:token)
+    end
+
+    it 'redirects to /account' do
+      patch :update, params: { user_id: 'tu123' }
+      expect(response).to redirect_to account_path
+    end
+
+    it 'has a success flash message' do
+      patch :update, params: { user_id: 'tu123' }
+      expect(controller.flash).to be_key('success')
+    end
+  end
+
+  # DELETE /users/$uni/api_token
+  describe 'DELETE #destroy' do
+    before do
+      FactoryBot.build(:user, uid: 'tu123')
+      user = User.find_by(uid: 'tu123')
+      FactoryBot.create(:mcp_token, authorizable: user)
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    it 'redirects to /account' do
+      delete :destroy, params: { user_id: 'tu123' }
+      expect(response).to redirect_to account_path
+    end
+
+    it 'has a success flash message' do
+      delete :destroy, params: { user_id: 'tu123' }
+      expect(controller.flash).to be_key('success')
+    end
+  end
 end

--- a/spec/factories/token.rb
+++ b/spec/factories/token.rb
@@ -6,4 +6,10 @@ FactoryBot.define do
     token { 'token-value' }
     association :authorizable, factory: :api_client, strategy: :create
   end
+
+  factory :mcp_token, class: 'Token' do
+    scope { Token::MCP }
+    token { 'mcp-token-value' }
+    association :authorizable, factory: :user, strategy: :build
+  end
 end

--- a/spec/factories/token.rb
+++ b/spec/factories/token.rb
@@ -10,6 +10,6 @@ FactoryBot.define do
   factory :mcp_token, class: 'Token' do
     scope { Token::MCP }
     token { 'mcp-token-value' }
-    association :authorizable, factory: :user, strategy: :build
+    association :authorizable, factory: :user, strategy: :create
   end
 end

--- a/spec/features/admin/token_spec.rb
+++ b/spec/features/admin/token_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'admin token management', js: true, type: :feature do
+  include_context 'admin user for feature'
+
+  context 'when there are no tokens' do
+    context 'when visiting the token management page' do
+      it 'does not show the table' do
+        visit admin_tokens_path
+        expect(page).not_to have_css('table#api-tokens-table')
+      end
+    end
+  end
+
+  context 'when there are tokens' do
+    before do
+      current_user = User.find_by(uid: 'ta123')
+      FactoryBot.create(:mcp_token, authorizable: current_user)
+      FactoryBot.create(:token)
+      visit admin_tokens_path
+    end
+
+    context 'when visiting the token management page' do
+      it 'displays the api tokens management table' do
+        find(:table, 'API Tokens')
+      end
+
+      it 'lists all API Tokens' do
+        expect(all('tbody tr').length).to eq(Token.all.length)
+      end
+
+      it 'lists token owner' do
+        find('td', text: 'Test Admin')
+        find('td', text: 'Test Service')
+      end
+
+      it 'lists token scope' do
+        find('td', text: 'MCP')
+        find('td', text: 'DATA_FEED')
+      end
+
+      it 'includes a delete button for each row' do
+        expect(all(:button, 'Delete Token').length).to eq(2)
+      end
+
+      it 'includes a show/hide toggle for each row' do
+        expect(all(:button, 'Show Value').length).to eq(2)
+      end
+    end
+
+    context 'when showing/hiding tokens' do
+      it 'initially hides all tokens' do
+        expect(page).not_to have_css('td', text: 'mcp-token-value')
+      end
+
+      it 'clicking toggle shows the token' do
+        all(:button, 'Show Value').first.click
+        find('td', text: Token.first.token)
+        # all(:button, 'Show Value').find { |node| node.}
+      end
+    end
+
+    context 'when deleting an API token' do
+      it 'renders flash message' do
+        accept_confirm { all(:button, text: 'Delete Token').first.click }
+        find(:table, 'API Tokens')
+        expect(page).to have_content('Token successfully deleted.')
+      end
+
+      it 'removes the row from the table' do
+        accept_confirm { all(:button, text: 'Delete Token').first.click }
+        expect(page).to have_content('Token successfully deleted.')
+        expect(all(:button, 'Delete Token').length).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/features/myaccount_spec.rb
+++ b/spec/features/myaccount_spec.rb
@@ -40,7 +40,7 @@ describe 'My Account', type: :feature do
     end
   end
 
-  context 'generating a token' do
+  context 'generating a new token' do
     before do
       click_button 'Generate Token'
     end
@@ -50,7 +50,55 @@ describe 'My Account', type: :feature do
     end
 
     it 'shows the new token' do
-      expect(page).to have_css('label', text: 'Personal API Token')
+      expect(page).to have_css('label', text: 'Personal MCP API Token')
+    end
+  end
+
+  context 'refreshing a token' do
+    let(:current_user) { User.find_by(uid: 'tu123') }
+
+    before do
+      FactoryBot.create(:mcp_token, authorizable: current_user)
+      visit account_path
+    end
+
+    it 'displays the current token first' do
+      expect(page).to have_css('label', text: 'Personal MCP API Token')
+      expect(page).to have_field('Personal MCP API Token', with: 'mcp-token-value', disabled: true)
+    end
+
+    it 'creates a new token' do
+      old_token = find_field('Personal MCP API Token', disabled: true).value
+      click_button 'Generate New Token'
+      new_token = find_field('Personal MCP API Token', disabled: true).value
+      expect(old_token).not_to eq(new_token)
+    end
+
+    it 'renders flash message' do
+      click_button 'Generate New Token'
+      expect(page).to have_content 'Successfully refreshed API token.'
+    end
+  end
+
+  context 'deleting a token' do
+    let(:current_user) { User.find_by(uid: 'tu123') }
+
+    before do
+      FactoryBot.create(:mcp_token, authorizable: current_user)
+      visit account_path
+      click_button 'Delete Token'
+    end
+
+    it 'removes the token field' do
+      expect(page).not_to have_field('Personal MCP API Token', disabled: true)
+    end
+
+    it 'renders flash message' do
+      expect(page).to have_content 'Successfully deleted API token.'
+    end
+
+    it 'renders new token button' do
+      expect(page).to have_button('Generate Token')
     end
   end
 end

--- a/spec/features/myacount_js_spec.rb
+++ b/spec/features/myacount_js_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe 'My Account', type: :feature, js: true do
+  include_context 'non-admin user for feature'
+
+  before do
+    visit account_path
+  end
+
+  context 'refreshing a token' do
+    let(:current_user) { User.find_by(uid: 'tu123') }
+
+    before do
+      FactoryBot.create(:mcp_token, authorizable: current_user)
+      visit account_path
+    end
+
+    it 'renders a confirmation dialog' do
+      accept_confirm { click_button 'Generate New Token' }
+      expect(page).to have_field('Personal MCP API Token', disabled: true)
+    end
+  end
+
+  context 'deleting a token' do
+    let(:current_user) { User.find_by(uid: 'tu123') }
+
+    before do
+      FactoryBot.create(:mcp_token, authorizable: current_user)
+      visit account_path
+    end
+
+    it 'renders a confirmation dialog' do
+      accept_confirm { click_button 'Delete Token' }
+      expect(page).not_to have_field('Personal MCP API Token', disabled: true)
+    end
+  end
+end

--- a/spec/features/myacount_js_spec.rb
+++ b/spec/features/myacount_js_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'My Account', type: :feature, js: true do

--- a/spec/views/user/account.html.erb_spec.rb
+++ b/spec/views/user/account.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'user/account', type: :view do
   end
 
   it 'renders token text box label' do
-    expect(rendered).to have_css('label', text: 'Personal API Token')
+    expect(rendered).to have_css('label', text: 'Personal MCP API Token')
   end
 
   it 'renders token text box' do


### PR DESCRIPTION
## [Jira Ticket](https://columbiauniversitylibraries.atlassian.net/browse/ACHYDRA-462)
***
This PR adds admin token management features to AC, as well as some additional token management features for users.
It also adds a new token scope "MCP" to replace the existing API one. This is a more accurate name and the "API" will now be reserved for normal API usage (currently unrestricted, but will be implemented at a later time).

### Admin Token Management
There is a new admin panel section called "API Token Management" that displays a table with all API token, each having a button to delete the token and a toggle button to show its value:
<img width="1189" height="736" alt="Screenshot 2026-07-07 at 5 03 53 PM" src="https://github.com/user-attachments/assets/92535e2a-af17-4e5d-b754-ef9877c5c929" />
There is a new admin_tokens_controller that handles deletion of tokens (of any type). Actions are authorized for admin only.

### User Account Page
The user token controller now supports update (refreshing a token) and destroy actions. The view includes two buttons now when a token exists to use those features:
<img width="880" height="217" alt="Screenshot 2026-07-07 at 5 03 41 PM" src="https://github.com/user-attachments/assets/c9777f2f-b74c-4292-8fac-46f615888575" />

### Note
When we deploy this, we should run the `user_mcp_token` data migration rake task to update any existing API scoped tokens to MCP scope.